### PR TITLE
Add getter/setter for the device GAP role

### DIFF
--- a/ble/Gap.h
+++ b/ble/Gap.h
@@ -419,6 +419,20 @@ protected:
      */
 public:
     /**
+     * Returns the current GAP role for the device.
+     */
+    Role_t getRole(void) const {
+        return _role;
+    }
+    
+    /**
+     * Set the GAP role for the device.
+     */
+    void setRole(const Role_t role) {
+        _role = role;
+    }
+    
+    /**
      * Returns the current GAP state of the device using a bitmask which
      * describes whether the device is advertising and/or connected.
      */
@@ -949,6 +963,7 @@ public:
 
 protected:
     Gap() :
+        _role(PERIPHERAL),
         _advParams(),
         _advPayload(),
         _scanningParams(),
@@ -1012,6 +1027,7 @@ public:
     }
 
 protected:
+    Role_t                           _role;
     GapAdvertisingParams             _advParams;
     GapAdvertisingData               _advPayload;
     GapScanningParams                _scanningParams;


### PR DESCRIPTION
By default, the role is set to GAP::PERIPHERAL