### PR TITLE
Add st-ble-shield as a possible target dependency.

### DIFF
--- a/module.json
+++ b/module.json
@@ -20,6 +20,9 @@
   ],
   "dependencies": {},
   "targetDependencies": {
+    "st-ble-shield": {
+      "x-nucleo-idb0xa1": "ARMmbed/ble-x-nucleo-idb0xa1"
+    },
     "nrf51822": {
       "ble-nrf51822": "~0.4.7"
     },


### PR DESCRIPTION
This change will allow developers to build  BLE applications on the st-ble-shield. The shield reference is x-nucleo-idb0xa1.

If you want to build software on this board, you should use the target "frdm-k64f-st-ble-gcc" which is not yet on the yotta registry but is available at https://github.com/ARMmbed/target-frdm-k64f-st-ble-gcc.git .