### PR TITLE
Fixed include problem in HealthThermometer header

### DIFF
--- a/ble/services/HealthThermometerService.h
+++ b/ble/services/HealthThermometerService.h
@@ -17,7 +17,7 @@
 #ifndef __BLE_HEALTH_THERMOMETER_SERVICE_H__
 #define __BLE_HEALTH_THERMOMETER_SERVICE_H__
 
-#include "BLE.h"
+#include "ble/BLE.h"
 
 /**
 * @class HealthThermometerService


### PR DESCRIPTION
Modified the HealthThermometer header file to include BLE.h from
ble/BLE.h.