### PR TITLE
Externalization of stack cleaning for uri beacon service

### DIFF
--- a/ble/services/URIBeaconConfigService.h
+++ b/ble/services/URIBeaconConfigService.h
@@ -186,13 +186,12 @@ class URIBeaconConfigService {
         ble.gap().setAdvertisingInterval(GapAdvertisingParams::MSEC_TO_ADVERTISEMENT_DURATION_UNITS(ADVERTISING_INTERVAL_MSEC));
     }
 
-    /* Helper function to switch to the non-connectible normal mode for URIBeacon. This gets called after a timeout. */
+    /* 
+     * Helper function to switch to the non-connectible normal mode for URIBeacon. This gets called after a timeout. 
+     * The stack should be clear of any existing services and advertising states before calling this function. 
+     */
     void setupURIBeaconAdvertisements()
     {
-        /* Reinitialize the BLE stack. This will clear away the existing services and advertising state. */
-        ble.shutdown();
-        ble.init();
-
         // Fields from the Service
         unsigned beaconPeriod                                 = params.beaconPeriod;
         unsigned txPowerMode                                  = params.txPowerMode;


### PR DESCRIPTION
This is a short term solution for the URI beacon service.

The function BLE::init and this change can't be properly propagated to URIBeaconConfigService.
The problem is that the BLE::init callback doesn't hold a context and a member function (in this case URIBeaconConfigService::setupURIBeaconAdvertisements) needs a context to be called.

Two solutions: 
   * The general one: provide a way to embed a context into the the callback of BLE::init
   * This specific one: externalize stack cleaning outside the URIBeaconConfigService



