### PR TITLE
Remove persistant callbacks

### DIFF
--- a/ble/CallChainOfFunctionPointersWithContext.h
+++ b/ble/CallChainOfFunctionPointersWithContext.h
@@ -118,9 +118,15 @@ public:
 
         while (current) {
             if(*current == toDetach) { 
-                if(previous == NULL) { 
+                if(previous == NULL) {
+                    if(currentCalled == current) { 
+                        currentCalled = NULL;
+                    }
                     chainHead = current->getNext();
                 } else {
+                    if(currentCalled == current) { 
+                        currentCalled = previous;
+                    }
                     previous->chainAsNext(current->getNext());
                 }
                 delete current;
@@ -155,17 +161,23 @@ public:
      *        chained FunctionPointers.
      */
     void call(ContextType context) {
-        if (chainHead) {
-            chainHead->call(context);
-        }
+        ((const CallChainOfFunctionPointersWithContext*) this)->call(context);
     }
 
     /**
      * @brief same as above but const 
      */
     void call(ContextType context) const {
-        if (chainHead) {
-            chainHead->call(context);
+        currentCalled = chainHead;
+
+        while(currentCalled) { 
+            currentCalled->call(context);
+            // if this was the head and the call removed the head
+            if(currentCalled == NULL) { 
+                currentCalled = chainHead;
+            } else {
+                currentCalled = currentCalled->getNext();
+            }
         }
     }
 
@@ -197,6 +209,8 @@ private:
 
 private:
     pFunctionPointerWithContext_t chainHead;
+    mutable pFunctionPointerWithContext_t currentCalled;
+
 
     /* Disallow copy constructor and assignment operators. */
 private:

--- a/ble/CallChainOfFunctionPointersWithContext.h
+++ b/ble/CallChainOfFunctionPointersWithContext.h
@@ -124,13 +124,12 @@ public:
                     previous->chainAsNext(current->getNext());
                 }
                 delete current;
-                return true;
+                return;
             }
 
             previous = current;
             current = current->getNext();
         }
-        return false;
     }
 
     /** Clear the call chain (remove all functions in the chain).

--- a/ble/CallChainOfFunctionPointersWithContext.h
+++ b/ble/CallChainOfFunctionPointersWithContext.h
@@ -97,6 +97,14 @@ public:
         return common_add(new FunctionPointerWithContext<ContextType>(tptr, mptr));
     }
 
+    /** Add a function at the front of the chain.
+     *
+     *  @param func The FunctionPointerWithContext to add.
+     */
+    void add(const FunctionPointerWithContext<ContextType>& func) {
+        common_add(new FunctionPointerWithContext<ContextType>(func));
+    }
+
     /** 
      * Detach a function pointer from a callchain
      * 
@@ -151,6 +159,29 @@ public:
         if (chainHead) {
             chainHead->call(context);
         }
+    }
+
+    /**
+     * @brief same as above but const 
+     */
+    void call(ContextType context) const {
+        if (chainHead) {
+            chainHead->call(context);
+        }
+    }
+
+    /**
+     * @brief same as above but with function call operator
+     */
+    void operator()(ContextType context) const {
+        call(context);
+    }
+
+    typedef void (CallChainOfFunctionPointersWithContext::*bool_type)() const;
+    void True() const {}
+
+    operator bool_type() const {
+        return chainHead == NULL ? 0 : &CallChainOfFunctionPointersWithContext::True;
     }
 
 private:

--- a/ble/CallChainOfFunctionPointersWithContext.h
+++ b/ble/CallChainOfFunctionPointersWithContext.h
@@ -97,6 +97,34 @@ public:
         return common_add(new FunctionPointerWithContext<ContextType>(tptr, mptr));
     }
 
+    /** 
+     * Detach a function pointer from a callchain
+     * 
+     * @oaram toDetach FunctionPointerWithContext to detach from this callchain
+     * 
+     * @return true if a function pointer has been detached and false otherwise
+     */ 
+    void detach(const FunctionPointerWithContext<ContextType>& toDetach) { 
+        pFunctionPointerWithContext_t current = chainHead;
+        pFunctionPointerWithContext_t previous = NULL;
+
+        while (current) {
+            if(*current == toDetach) { 
+                if(previous == NULL) { 
+                    chainHead = current->getNext();
+                } else {
+                    previous->chainAsNext(current->getNext());
+                }
+                delete current;
+                return true;
+            }
+
+            previous = current;
+            current = current->getNext();
+        }
+        return false;
+    }
+
     /** Clear the call chain (remove all functions in the chain).
      */
     void clear(void) {

--- a/ble/DiscoveredCharacteristic.h
+++ b/ble/DiscoveredCharacteristic.h
@@ -137,6 +137,11 @@ public:
      */
     ble_error_t write(uint16_t length, const uint8_t *value) const;
 
+    /** 
+     * Same as above but register the callback wich will be called once the data has been written
+     */
+    ble_error_t write(uint16_t length, const uint8_t *value, const GattClient::WriteCallback_t& onRead) const;
+
     void setupLongUUID(UUID::LongUUIDBytes_t longUUID) {
         uuid.setupLong(longUUID);
     }

--- a/ble/DiscoveredCharacteristic.h
+++ b/ble/DiscoveredCharacteristic.h
@@ -83,6 +83,8 @@ public:
      */
     ble_error_t read(uint16_t offset = 0) const;
 
+    ble_error_t read(uint16_t offset, const GattClient::ReadCallback_t& onRead) const;
+
     /**
      * Perform a write without response procedure.
      *

--- a/ble/FunctionPointerWithContext.h
+++ b/ble/FunctionPointerWithContext.h
@@ -94,6 +94,13 @@ public:
         }
     }
 
+    /**
+     * @brief Same as above
+     */
+    void operator()(ContextType context) const {
+        call(context);
+    }
+
     /** Same as above, workaround for mbed os FunctionPointer implementation. */
     void call(ContextType context) {
         _caller(this, context);

--- a/ble/FunctionPointerWithContext.h
+++ b/ble/FunctionPointerWithContext.h
@@ -111,6 +111,19 @@ public:
         }
     }
 
+    typedef void (FunctionPointerWithContext::*bool_type)() const;
+
+    /** 
+     * implementation of safe bool operator
+     */
+    operator bool_type() const {
+        if(_function || _memberFunctionAndPointer._object) { 
+            return &FunctionPointerWithContext::trueValue;
+        }
+
+        return 0;
+    }
+
     /**
      * Set up an external FunctionPointer as a next in the chain of related
      * callbacks. Invoking call() on the head FunctionPointer will invoke all
@@ -155,6 +168,12 @@ private:
             self->_function(context);
         }
     }
+
+    /**
+     * @brief True value used in conversion to bool, this function is useless 
+     * beside this usage
+     */
+    void trueValue() const {}
 
     struct MemberFunctionAndPtr {
         /*

--- a/ble/FunctionPointerWithContext.h
+++ b/ble/FunctionPointerWithContext.h
@@ -104,11 +104,6 @@ public:
     /** Same as above, workaround for mbed os FunctionPointer implementation. */
     void call(ContextType context) {
         _caller(this, context);
-
-        /* Propagate the call to next in the chain. */
-        if (_next) {
-            _next->call(context);
-        }
     }
 
     typedef void (FunctionPointerWithContext::*bool_type)() const;

--- a/ble/FunctionPointerWithContext.h
+++ b/ble/FunctionPointerWithContext.h
@@ -18,12 +18,13 @@
 #define MBED_FUNCTIONPOINTER_WITH_CONTEXT_H
 
 #include <string.h>
+#include "SafeBool.h"
 
 /** A class for storing and calling a pointer to a static or member void function
  *  that takes a context.
  */
 template <typename ContextType>
-class FunctionPointerWithContext {
+class FunctionPointerWithContext : public SafeBool<FunctionPointerWithContext<ContextType> > {
 public:
     typedef FunctionPointerWithContext<ContextType> *pFunctionPointerWithContext_t;
     typedef const FunctionPointerWithContext<ContextType> *cpFunctionPointerWithContext_t;
@@ -87,11 +88,6 @@ public:
      *  many FunctionPointers in a chain. */
     void call(ContextType context) const {
         _caller(this, context);
-
-        /* Propagate the call to next in the chain. */
-        if (_next) {
-            _next->call(context);
-        }
     }
 
     /**
@@ -103,7 +99,7 @@ public:
 
     /** Same as above, workaround for mbed os FunctionPointer implementation. */
     void call(ContextType context) {
-        _caller(this, context);
+        ((const FunctionPointerWithContext*)  this)->call(context);
     }
 
     typedef void (FunctionPointerWithContext::*bool_type)() const;
@@ -111,12 +107,8 @@ public:
     /** 
      * implementation of safe bool operator
      */
-    operator bool_type() const {
-        if(_function || _memberFunctionAndPointer._object) { 
-            return &FunctionPointerWithContext::trueValue;
-        }
-
-        return 0;
+    bool toBool() const {
+        return (_function || _memberFunctionAndPointer._object);
     }
 
     /**
@@ -163,12 +155,6 @@ private:
             self->_function(context);
         }
     }
-
-    /**
-     * @brief True value used in conversion to bool, this function is useless 
-     * beside this usage
-     */
-    void trueValue() const {}
 
     struct MemberFunctionAndPtr {
         /*

--- a/ble/Gap.h
+++ b/ble/Gap.h
@@ -897,35 +897,56 @@ public:
     /**
      * Set up a callback for timeout events. Refer to TimeoutSource_t for
      * possible event types.
+     * @note It is possible to unregister callbacks using onTimeout().detach(callback)
      */
     void onTimeout(TimeoutEventCallback_t callback) {
         timeoutCallbackChain.add(callback);
     }
 
+    /**
+     * @brief provide access to the callchain of timeout event callbacks
+     * It is possible to register callbacks using onTimeout().add(callback);
+     * It is possible to unregister callbacks using onTimeout().detach(callback) 
+     * @return The timeout event callbacks chain
+     */
     TimeoutEventCallbackChain_t& onTimeout() {
         return timeoutCallbackChain;
     }
 
     /**
      * Append to a chain of callbacks to be invoked upon GAP connection.
+     * @note It is possible to unregister callbacks using onConnection().detach(callback)
      */
     void onConnection(ConnectionEventCallback_t callback) {connectionCallChain.add(callback);}
 
     template<typename T>
     void onConnection(T *tptr, void (T::*mptr)(const ConnectionCallbackParams_t*)) {connectionCallChain.add(tptr, mptr);}
 
+    /**
+     * @brief provide access to the callchain of connection event callbacks
+     * It is possible to register callbacks using onConnection().add(callback);
+     * It is possible to unregister callbacks using onConnection().detach(callback) 
+     * @return The connection event callbacks chain
+     */
     ConnectionEventCallbackChain_t& onconnection() { 
         return connectionCallChain;
     }
 
     /**
      * Append to a chain of callbacks to be invoked upon GAP disconnection.
+     * @note It is possible to unregister callbacks using onDisconnection().detach(callback)
      */
     void onDisconnection(DisconnectionEventCallback_t callback) {disconnectionCallChain.add(callback);}
 
     template<typename T>
     void onDisconnection(T *tptr, void (T::*mptr)(const DisconnectionCallbackParams_t*)) {disconnectionCallChain.add(tptr, mptr);}
 
+    /**
+     * @brief provide access to the callchain of disconnection event callbacks
+     * It is possible to register callbacks using onDisconnection().add(callback);
+     * It is possible to unregister callbacks using onDisconnection().detach(callback) 
+     * @return The disconnection event callbacks chain
+     */
     DisconnectionEventCallbackChain_t& onDisconnection() {
         return disconnectionCallChain;
     }
@@ -959,15 +980,10 @@ public:
      */
     void onRadioNotification(void (*callback)(bool param)) {
         radioNotificationCallback.attach(callback);
-        // why does it start radio notification ? It is not even indicated in the 
-        // doc that it start the listening process
-        initRadioNotification();
     }
     template <typename T>
     void onRadioNotification(T *tptr, void (T::*mptr)(bool)) {
         radioNotificationCallback.attach(tptr, mptr);
-        // why does it start radio notification ?
-        initRadioNotification();
     }
 
 protected:

--- a/ble/Gap.h
+++ b/ble/Gap.h
@@ -143,7 +143,9 @@ public:
     typedef FunctionPointerWithContext<TimeoutSource_t> TimeoutEventCallback_t;
     typedef CallChainOfFunctionPointersWithContext<TimeoutSource_t> TimeoutEventCallbackChain_t;
 
-    typedef void (*ConnectionEventCallback_t)(const ConnectionCallbackParams_t *params);
+    typedef FunctionPointerWithContext<const ConnectionCallbackParams_t *> ConnectionEventCallback_t;
+    typedef CallChainOfFunctionPointersWithContext<const ConnectionCallbackParams_t *> ConnectionEventCallbackChain_t;
+
     typedef void (*DisconnectionEventCallback_t)(const DisconnectionCallbackParams_t *params);
     typedef FunctionPointerWithContext<bool> RadioNotificationEventCallback_t;
 
@@ -910,6 +912,10 @@ public:
     template<typename T>
     void onConnection(T *tptr, void (T::*mptr)(const ConnectionCallbackParams_t*)) {connectionCallChain.add(tptr, mptr);}
 
+    ConnectionEventCallbackChain_t& onconnection() { 
+        return connectionCallChain;
+    }
+
     /**
      * Append to a chain of callbacks to be invoked upon GAP disconnection.
      */
@@ -1027,7 +1033,7 @@ protected:
     TimeoutEventCallbackChain_t           timeoutCallbackChain;
     RadioNotificationEventCallback_t radioNotificationCallback;
     AdvertisementReportCallback_t    onAdvertisementReport;
-    CallChainOfFunctionPointersWithContext<const ConnectionCallbackParams_t*>    connectionCallChain;
+    ConnectionEventCallbackChain_t connectionCallChain;
     CallChainOfFunctionPointersWithContext<const DisconnectionCallbackParams_t*> disconnectionCallChain;
 
 private:

--- a/ble/Gap.h
+++ b/ble/Gap.h
@@ -959,11 +959,14 @@ public:
      */
     void onRadioNotification(void (*callback)(bool param)) {
         radioNotificationCallback.attach(callback);
+        // why does it start radio notification ? It is not even indicated in the 
+        // doc that it start the listening process
         initRadioNotification();
     }
     template <typename T>
     void onRadioNotification(T *tptr, void (T::*mptr)(bool)) {
         radioNotificationCallback.attach(tptr, mptr);
+        // why does it start radio notification ?
         initRadioNotification();
     }
 
@@ -1036,10 +1039,10 @@ protected:
     bool                             scanningActive;
 
 protected:
-    TimeoutEventCallbackChain_t           timeoutCallbackChain;
-    RadioNotificationEventCallback_t radioNotificationCallback;
-    AdvertisementReportCallback_t    onAdvertisementReport;
-    ConnectionEventCallbackChain_t connectionCallChain;
+    TimeoutEventCallbackChain_t       timeoutCallbackChain;
+    RadioNotificationEventCallback_t  radioNotificationCallback;
+    AdvertisementReportCallback_t     onAdvertisementReport;
+    ConnectionEventCallbackChain_t    connectionCallChain;
     DisconnectionEventCallbackChain_t disconnectionCallChain;
 
 private:

--- a/ble/Gap.h
+++ b/ble/Gap.h
@@ -146,7 +146,9 @@ public:
     typedef FunctionPointerWithContext<const ConnectionCallbackParams_t *> ConnectionEventCallback_t;
     typedef CallChainOfFunctionPointersWithContext<const ConnectionCallbackParams_t *> ConnectionEventCallbackChain_t;
 
-    typedef void (*DisconnectionEventCallback_t)(const DisconnectionCallbackParams_t *params);
+    typedef FunctionPointerWithContext<const DisconnectionCallbackParams_t*> DisconnectionEventCallback_t;
+    typedef CallChainOfFunctionPointersWithContext<const DisconnectionCallbackParams_t*> DisconnectionEventCallbackChain_t;    
+
     typedef FunctionPointerWithContext<bool> RadioNotificationEventCallback_t;
 
     /*
@@ -924,6 +926,10 @@ public:
     template<typename T>
     void onDisconnection(T *tptr, void (T::*mptr)(const DisconnectionCallbackParams_t*)) {disconnectionCallChain.add(tptr, mptr);}
 
+    DisconnectionEventCallbackChain_t& onDisconnection() {
+        return disconnectionCallChain;
+    }
+
     /**
      * Set the application callback for radio-notification events.
      *
@@ -1034,7 +1040,7 @@ protected:
     RadioNotificationEventCallback_t radioNotificationCallback;
     AdvertisementReportCallback_t    onAdvertisementReport;
     ConnectionEventCallbackChain_t connectionCallChain;
-    CallChainOfFunctionPointersWithContext<const DisconnectionCallbackParams_t*> disconnectionCallChain;
+    DisconnectionEventCallbackChain_t disconnectionCallChain;
 
 private:
     /* Disallow copy and assignment. */

--- a/ble/GattClient.h
+++ b/ble/GattClient.h
@@ -246,24 +246,40 @@ public:
     /* Event callback handlers. */
 public:
     /**
-     * Set up a callback for read response events.
+     * Set up a callback for read response events. 
+     * It is possible to remove registered callbacks using 
+     * onDataRead().detach(callbackToRemove)
      */
     void onDataRead(ReadCallback_t callback) {
         onDataReadCallbackChain.add(callback);
     }
 
+    /**
+     * @brief provide access to the callchain of read callbacks
+     * It is possible to register callbacks using onDataRead().add(callback);
+     * It is possible to unregister callbacks using onDataRead().detach(callback) 
+     * @return The read callbacks chain
+     */
     ReadCallbackChain_t& onDataRead() {
         return onDataReadCallbackChain;
     }
 
     /**
      * Set up a callback for write response events.
+     * It is possible to remove registered callbacks using 
+     * onDataWritten().detach(callbackToRemove).
      * @Note: Write commands (issued using writeWoResponse) don't generate a response.
      */
     void onDataWritten(WriteCallback_t callback) {
         onDataWriteCallbackChain.add(callback);
     }
 
+    /**
+     * @brief provide access to the callchain of data written callbacks
+     * It is possible to register callbacks using onDataWritten().add(callback);
+     * It is possible to unregister callbacks using onDataWritten().detach(callback) 
+     * @return The data written callbacks chain
+     */
     WriteCallbackChain_t& onDataWritten() { 
         return onDataWriteCallbackChain;
     }
@@ -292,11 +308,19 @@ public:
      * Set up a callback for when the GATT client receives an update event
      * corresponding to a change in the value of a characteristic on the remote
      * GATT server.
+     * It is possible to remove registered callbacks using onHVX().detach(callbackToRemove).
      */
     void onHVX(HVXCallback_t callback) {
         onHVXCallbackChain.add(callback);
     }
 
+
+    /**
+     * @brief provide access to the callchain of HVX callbacks
+     * It is possible to register callbacks using onHVX().add(callback);
+     * It is possible to unregister callbacks using onHVX().detach(callback) 
+     * @return The HVX callbacks chain
+     */
     HVXCallbackChain_t& onHVX() { 
         return onHVXCallbackChain;
     }

--- a/ble/GattServer.h
+++ b/ble/GattServer.h
@@ -274,6 +274,8 @@ public:
      *
      * @Note: It is also possible to set up a callback into a member function of
      * some object.
+     * 
+     * @Note It is possible to unregister a callback using onDataWritten().detach(callback)
      */
     void onDataWritten(const DataWrittenCallback_t& callback) {dataWrittenCallChain.add(callback);}
     template <typename T>
@@ -281,6 +283,12 @@ public:
         dataWrittenCallChain.add(objPtr, memberPtr);
     }
 
+    /**
+     * @brief provide access to the callchain of data written event callbacks
+     * It is possible to register callbacks using onDataWritten().add(callback);
+     * It is possible to unregister callbacks using onDataWritten().detach(callback) 
+     * @return The data written event callbacks chain
+     */    
     DataWrittenCallbackChain_t& onDataWritten() {
         return dataWrittenCallChain;
     }
@@ -300,6 +308,8 @@ public:
      *
      * @Note: It is also possible to set up a callback into a member function of
      * some object.
+     *
+     * @Note It is possible to unregister a callback using onDataRead().detach(callback)
      *
      * @return BLE_ERROR_NOT_IMPLEMENTED if this functionality isn't available;
      *         else BLE_ERROR_NONE.
@@ -322,6 +332,12 @@ public:
         return BLE_ERROR_NONE;
     }
 
+    /**
+     * @brief provide access to the callchain of data read event callbacks
+     * It is possible to register callbacks using onDataRead().add(callback);
+     * It is possible to unregister callbacks using onDataRead().detach(callback) 
+     * @return The data read event callbacks chain
+     */
     DataReadCallbackChain_t& onDataRead() {
         return dataReadCallChain;
     }

--- a/ble/GattServer.h
+++ b/ble/GattServer.h
@@ -26,9 +26,18 @@
 
 class GattServer {
 public:
+
     /* Event callback handlers. */
-    typedef void (*EventCallback_t)(GattAttribute::Handle_t attributeHandle);
-    typedef void (*ServerEventCallback_t)(void);                    /**< Independent of any particular attribute. */
+    typedef FunctionPointerWithContext<unsigned> DataSentCallback_t;
+    typedef CallChainOfFunctionPointersWithContext<unsigned> DataSentCallbackChain_t;
+
+    typedef FunctionPointerWithContext<const GattWriteCallbackParams*> DataWrittenCallback_t;
+    typedef CallChainOfFunctionPointersWithContext<const GattWriteCallbackParams*> DataWrittenCallbackChain_t;    
+
+    typedef FunctionPointerWithContext<const GattReadCallbackParams*> DataReadCallback_t;
+    typedef CallChainOfFunctionPointersWithContext<const GattReadCallbackParams *> DataReadCallbackChain_t;
+
+    typedef FunctionPointerWithContext<GattAttribute::Handle_t> EventCallback_t;
 
 protected:
     GattServer() :
@@ -238,10 +247,17 @@ public:
      * @Note: It is also possible to set up a callback into a member function of
      * some object.
      */
-    void onDataSent(void (*callback)(unsigned count)) {dataSentCallChain.add(callback);}
+    void onDataSent(const DataSentCallback_t& callback) {dataSentCallChain.add(callback);}
     template <typename T>
     void onDataSent(T *objPtr, void (T::*memberPtr)(unsigned count)) {
         dataSentCallChain.add(objPtr, memberPtr);
+    }
+
+    /**
+     * @brief get the callback chain called when the event DATA_EVENT is triggered. 
+     */
+    DataSentCallbackChain_t& onDataSent() { 
+        return dataSentCallChain;
     }
 
     /**
@@ -259,10 +275,14 @@ public:
      * @Note: It is also possible to set up a callback into a member function of
      * some object.
      */
-    void onDataWritten(void (*callback)(const GattWriteCallbackParams *eventDataP)) {dataWrittenCallChain.add(callback);}
+    void onDataWritten(const DataWrittenCallback_t& callback) {dataWrittenCallChain.add(callback);}
     template <typename T>
     void onDataWritten(T *objPtr, void (T::*memberPtr)(const GattWriteCallbackParams *context)) {
         dataWrittenCallChain.add(objPtr, memberPtr);
+    }
+
+    DataWrittenCallbackChain_t& onDataWritten() {
+        return dataWrittenCallChain;
     }
 
     /**
@@ -284,7 +304,7 @@ public:
      * @return BLE_ERROR_NOT_IMPLEMENTED if this functionality isn't available;
      *         else BLE_ERROR_NONE.
      */
-    ble_error_t onDataRead(void (*callback)(const GattReadCallbackParams *eventDataP)) {
+    ble_error_t onDataRead(const DataReadCallback_t& callback) {
         if (!isOnDataReadAvailable()) {
             return BLE_ERROR_NOT_IMPLEMENTED;
         }
@@ -300,6 +320,10 @@ public:
 
         dataReadCallChain.add(objPtr, memberPtr);
         return BLE_ERROR_NONE;
+    }
+
+    DataReadCallbackChain_t& onDataRead() {
+        return dataReadCallChain;
     }
 
     /**
@@ -323,15 +347,11 @@ public:
     /* Entry points for the underlying stack to report events back to the user. */
 protected:
     void handleDataWrittenEvent(const GattWriteCallbackParams *params) {
-        if (dataWrittenCallChain.hasCallbacksAttached()) {
-            dataWrittenCallChain.call(params);
-        }
+        dataWrittenCallChain.call(params);
     }
 
     void handleDataReadEvent(const GattReadCallbackParams *params) {
-        if (dataReadCallChain.hasCallbacksAttached()) {
-            dataReadCallChain.call(params);
-        }
+        dataReadCallChain.call(params);
     }
 
     void handleEvent(GattServerEvents::gattEvent_e type, GattAttribute::Handle_t attributeHandle) {
@@ -357,9 +377,7 @@ protected:
     }
 
     void handleDataSentEvent(unsigned count) {
-        if (dataSentCallChain.hasCallbacksAttached()) {
-            dataSentCallChain.call(count);
-        }
+        dataSentCallChain.call(count);
     }
 
 protected:
@@ -367,12 +385,12 @@ protected:
     uint8_t characteristicCount;
 
 private:
-    CallChainOfFunctionPointersWithContext<unsigned>                        dataSentCallChain;
-    CallChainOfFunctionPointersWithContext<const GattWriteCallbackParams *> dataWrittenCallChain;
-    CallChainOfFunctionPointersWithContext<const GattReadCallbackParams *>  dataReadCallChain;
-    EventCallback_t                                                         updatesEnabledCallback;
-    EventCallback_t                                                         updatesDisabledCallback;
-    EventCallback_t                                                         confirmationReceivedCallback;
+    DataSentCallbackChain_t    dataSentCallChain;
+    DataWrittenCallbackChain_t dataWrittenCallChain;
+    DataReadCallbackChain_t    dataReadCallChain;
+    EventCallback_t            updatesEnabledCallback;
+    EventCallback_t            updatesDisabledCallback;
+    EventCallback_t            confirmationReceivedCallback;
 
 private:
     /* Disallow copy and assignment. */

--- a/ble/SafeBool.h
+++ b/ble/SafeBool.h
@@ -1,0 +1,114 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef BLE_API_SAFE_BOOL_H_
+#define BLE_API_SAFE_BOOL_H_
+
+//safe bool idiom, see : http://www.artima.com/cppsource/safebool.html
+
+namespace SafeBool_ {
+/**
+ * @brief Base class for all intances of SafeBool, 
+ * This base class reduce instantiation of trueTag function
+ */
+class base {
+  template<typename>
+  friend class SafeBool;
+
+protected:
+    //the bool type is a pointer to method which can be used in boolean context
+  typedef void (base::*BoolType_t)() const;
+
+  // non implemented call, use to disallow conversion between unrelated types 
+  void invalidTag() const;
+
+  // member function which indicate true value
+  void trueTag() const {}
+};
+
+
+}
+
+/**
+ * @brief template class SafeBool use CRTP to made boolean conversion easy and correct.
+ * Derived class should implement the function bool toBool() const to make this work. Inheritance 
+ * should be public.
+ *
+ * @tparam T Type of the derived class
+ * 
+ * \code 
+ * 
+ * class A : public SafeBool<A> { 
+ * public:
+ * 
+ *      // boolean conversion
+ *      bool toBool() { 
+ *      
+ *      }  
+ * };
+ * 
+ * class B : public SafeBool<B> { 
+ * public:
+ * 
+ *      // boolean conversion
+ *      bool toBool() const { 
+ *      
+ *      }  
+ * };
+ * 
+ * A a;
+ * B b;
+ * 
+ * // will compile 
+ * if(a) { 
+ * 
+ * }
+ * 
+ * // compilation error 
+ * if(a == b) { 
+ * 
+ * }
+ * 
+ * 
+ * \endcode
+ */
+template <typename T> 
+class SafeBool : public SafeBool_::base {
+public:
+  /** 
+   * bool operator implementation, derived class has to provide bool toBool() const function.
+   */
+  operator BoolType_t() const {
+    return (static_cast<const T*>(this))->toBool()
+      ? &SafeBool<T>::trueTag : 0;
+  }
+};
+
+//Avoid conversion to bool between different classes
+template <typename T, typename U>
+void operator==(const SafeBool<T>& lhs,const SafeBool<U>& rhs) {
+    lhs.invalidTag();
+//    return false;
+}
+
+//Avoid conversion to bool between different classes
+template <typename T,typename U>
+void operator!=(const SafeBool<T>& lhs,const SafeBool<U>& rhs) {
+  lhs.invalidTag();
+//  return false;
+}
+
+#endif /* BLE_API_SAFE_BOOL_H_ */

--- a/ble/ServiceDiscovery.h
+++ b/ble/ServiceDiscovery.h
@@ -38,7 +38,7 @@ public:
      * framework. The application can safely make a persistent shallow-copy of
      * this object to work with the service beyond the callback.
      */
-    typedef void (*ServiceCallback_t)(const DiscoveredService *);
+    typedef FunctionPointerWithContext<const DiscoveredService *> ServiceCallback_t;
 
     /**
      * Callback type for when a matching characteristic is found during service-
@@ -48,12 +48,12 @@ public:
      * framework. The application can safely make a persistent shallow-copy of
      * this object to work with the characteristic beyond the callback.
      */
-    typedef void (*CharacteristicCallback_t)(const DiscoveredCharacteristic *);
+    typedef FunctionPointerWithContext<const DiscoveredCharacteristic *> CharacteristicCallback_t;
 
     /**
      * Callback type for when serviceDiscovery terminates.
      */
-    typedef void (*TerminationCallback_t)(Gap::Handle_t connectionHandle);
+    typedef FunctionPointerWithContext<Gap::Handle_t> TerminationCallback_t;
 
 public:
     /**

--- a/source/DiscoveredCharacteristic.cpp
+++ b/source/DiscoveredCharacteristic.cpp
@@ -33,7 +33,7 @@ DiscoveredCharacteristic::read(uint16_t offset) const
 
 struct OneShotReadCallback { 
     static void launch(GattClient* client, Gap::Handle_t connHandle, 
-                       GattAttribute::Handle_t handle,const GattClient::ReadCallback_t& cb) { 
+                       GattAttribute::Handle_t handle, const GattClient::ReadCallback_t& cb) { 
         OneShotReadCallback* oneShot = new OneShotReadCallback(client, connHandle, handle, cb);
         oneShot->attach();
         // delete will be made when this callback is called
@@ -107,7 +107,7 @@ DiscoveredCharacteristic::writeWoResponse(uint16_t length, const uint8_t *value)
 
 struct OneShotWriteCallback { 
     static void launch(GattClient* client, Gap::Handle_t connHandle, 
-                       GattAttribute::Handle_t handle,const GattClient::WriteCallback_t& cb) { 
+                       GattAttribute::Handle_t handle, const GattClient::WriteCallback_t& cb) { 
         OneShotWriteCallback* oneShot = new OneShotWriteCallback(client, connHandle, handle, cb);
         oneShot->attach();
         // delete will be made when this callback is called

--- a/source/DiscoveredCharacteristic.cpp
+++ b/source/DiscoveredCharacteristic.cpp
@@ -31,7 +31,6 @@ DiscoveredCharacteristic::read(uint16_t offset) const
     return gattc->read(connHandle, valueHandle, offset);
 }
 
-
 struct OneShotReadCallback { 
     static void launch(GattClient* client, Gap::Handle_t connHandle, 
                        GattAttribute::Handle_t handle,const GattClient::ReadCallback_t& cb) { 
@@ -45,7 +44,7 @@ private:
                         GattAttribute::Handle_t handle, const GattClient::ReadCallback_t& cb) : 
         _client(client),
         _connHandle(connHandle),
-        _handle(handle),
+        _handle(handle), 
         _callback(cb) { } 
 
     void attach() { 
@@ -54,7 +53,7 @@ private:
 
     void call(const GattReadCallbackParams* params) {
         // verifiy that it is the right characteristic on the right connection
-        if(params->connHandle == _connHandle && params->handle == _handle) { 
+        if (params->connHandle == _connHandle && params->handle == _handle) { 
             _callback(params);
             _client->onDataRead().detach(makeFunctionPointer(this, &OneShotReadCallback::call));
             delete this;
@@ -69,7 +68,7 @@ private:
 
 ble_error_t DiscoveredCharacteristic::read(uint16_t offset, const GattClient::ReadCallback_t& onRead) const {
     ble_error_t error = read(offset);
-    if(error) { 
+    if (error) { 
         return error;
     }
 
@@ -77,9 +76,6 @@ ble_error_t DiscoveredCharacteristic::read(uint16_t offset, const GattClient::Re
 
     return error;
 }
-
-
-
 
 ble_error_t
 DiscoveredCharacteristic::write(uint16_t length, const uint8_t *value) const
@@ -107,6 +103,52 @@ DiscoveredCharacteristic::writeWoResponse(uint16_t length, const uint8_t *value)
     }
 
     return gattc->write(GattClient::GATT_OP_WRITE_CMD, connHandle, valueHandle, length, value);
+}
+
+struct OneShotWriteCallback { 
+    static void launch(GattClient* client, Gap::Handle_t connHandle, 
+                       GattAttribute::Handle_t handle,const GattClient::WriteCallback_t& cb) { 
+        OneShotWriteCallback* oneShot = new OneShotWriteCallback(client, connHandle, handle, cb);
+        oneShot->attach();
+        // delete will be made when this callback is called
+    }
+
+private:
+    OneShotWriteCallback(GattClient* client, Gap::Handle_t connHandle, 
+                        GattAttribute::Handle_t handle, const GattClient::WriteCallback_t& cb) : 
+        _client(client),
+        _connHandle(connHandle),
+        _handle(handle), 
+        _callback(cb) { } 
+
+    void attach() { 
+        _client->onDataWritten(makeFunctionPointer(this, &OneShotWriteCallback::call));
+    }
+
+    void call(const GattWriteCallbackParams* params) {
+        // verifiy that it is the right characteristic on the right connection
+        if (params->connHandle == _connHandle && params->handle == _handle) { 
+            _callback(params);
+            _client->onDataWritten().detach(makeFunctionPointer(this, &OneShotWriteCallback::call));
+            delete this;
+        }
+    }
+
+    GattClient* _client;
+    Gap::Handle_t _connHandle;
+    GattAttribute::Handle_t _handle;
+    GattClient::WriteCallback_t _callback;
+};
+
+ble_error_t DiscoveredCharacteristic::write(uint16_t length, const uint8_t *value, const GattClient::WriteCallback_t& onRead) const {
+    ble_error_t error = write(length, value);
+    if (error) { 
+        return error;
+    }
+
+    OneShotWriteCallback::launch(gattc, connHandle, valueHandle, onRead);
+
+    return error;
 }
 
 ble_error_t

--- a/source/DiscoveredCharacteristic.cpp
+++ b/source/DiscoveredCharacteristic.cpp
@@ -33,28 +33,37 @@ DiscoveredCharacteristic::read(uint16_t offset) const
 
 
 struct OneShotReadCallback { 
-    static void launch(GattClient* client, const GattClient::ReadCallback_t& cb) { 
-        OneShotReadCallback* oneShot = new OneShotReadCallback(client, cb);
+    static void launch(GattClient* client, Gap::Handle_t connHandle, 
+                       GattAttribute::Handle_t handle,const GattClient::ReadCallback_t& cb) { 
+        OneShotReadCallback* oneShot = new OneShotReadCallback(client, connHandle, handle, cb);
         oneShot->attach();
         // delete will be made when this callback is called
     }
 
 private:
-    OneShotReadCallback(GattClient* client, const GattClient::ReadCallback_t& cb) : 
+    OneShotReadCallback(GattClient* client, Gap::Handle_t connHandle, 
+                        GattAttribute::Handle_t handle, const GattClient::ReadCallback_t& cb) : 
         _client(client),
+        _connHandle(connHandle),
+        _handle(handle),
         _callback(cb) { } 
 
     void attach() { 
         _client->onDataRead(makeFunctionPointer(this, &OneShotReadCallback::call));
     }
 
-    void call(const GattReadCallbackParams* params) { 
-        _callback(params);
-        _client->onDataRead().detach(makeFunctionPointer(this, &OneShotReadCallback::call));
-        delete this;
+    void call(const GattReadCallbackParams* params) {
+        // verifiy that it is the right characteristic on the right connection
+        if(params->connHandle == _connHandle && params->handle == _handle) { 
+            _callback(params);
+            _client->onDataRead().detach(makeFunctionPointer(this, &OneShotReadCallback::call));
+            delete this;
+        }
     }
 
     GattClient* _client;
+    Gap::Handle_t _connHandle;
+    GattAttribute::Handle_t _handle;
     GattClient::ReadCallback_t _callback;
 };
 
@@ -64,7 +73,7 @@ ble_error_t DiscoveredCharacteristic::read(uint16_t offset, const GattClient::Re
         return error;
     }
 
-    OneShotReadCallback::launch(gattc, onRead);
+    OneShotReadCallback::launch(gattc, connHandle, valueHandle, onRead);
 
     return error;
 }


### PR DESCRIPTION
This pull request improve `CallChainOfFunctionPointersWithContext`, `FunctionPointerWithContext` and provide a way to unregister callbacks previously registered in a callchain.

Changes in `FunctionPointerWithContext` are not minor, goals were to provide function pointer semantic and value semantic: 
  - support of copy constructor and assignement
  - support of equality operator
  - support of function call operator
  - support of safe comparison to bool
  - call does *not* call the `next` `FunctionPointerWithContext`, it is not its responsibility any more. This change can be seen as a breaking one. `FunctionPointerWithContext` needs to handle less things, is it a list, a node of a list, a call chain ? Unfortunately, mixing responsibilities hurt and I was forced to make this change if I wanted to make callback called only once worked.

`CallChainOfFunctionPointersWithContext` improvements: 
  - support some semantic of function pointer (comparison to bool and operator call). 
  - Provide detach operation, this operation remove a function pointer from the callchain, it is also allowed to remove a FunctionPointer while it is called. 
  - Handle calls of the callchain, it is not recursive anymore and it support the removal of any nodes while the callchain is traversed.

`DiscoveredCharacteristic` improvements:
  - read operation support continuation (callback)
  - write operation support continuation (callback)

`Gap` improvements: 
  - multiple timeout event handlers can be attached and detached
  - multiple connection event handlers can be attached and detached
  - multiple disconnection event handlers can be attached and detached

`GattClient` improvements:
  - multiple read event handlers can be attached and detached
  - multiple write event handlers can be attached and detached
  - multiple HVX event handlers can be attached and detached

`GattServer` improvements:
  - multiple data sent event handlers can be attached and detached
  - multiple data read event handlers can be attached and detached
  - multiple data written event handlers can be attached and detached
  - `EventCallback_t` is now a `FunctionPointerwithContext` instead of a plain function pointer

`ServiceDiscovery` callbacks are FunctionPointerWithcontext instances instead of plain function pointer
