### PR TITLE
First Doxygen output

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Hello!
 We are an open source project of [ARM mbed](https://www.mbed.com). Contributions via [pull request](https://github.com/ARMmbed/ble/pulls), and [bug reports](https://github.com/ARMmbed/ble/issues) are welcome!
 
-Please submit your pull request to the 'develop' branch of this module. Commits to develop will merge into master at the time of the next release.
+Please submit your pull request to the `develop` branch of [this module](https://github.com/ARMmbed/ble/tree/develop). Commits to develop will be merge into the master branch at the time of the next release.
 
 # Contributor agreement
 For your pull request to be accepted, we will need you to agree to our [contributor agreement](https://developer.mbed.org/contributor_agreement/) to give us the necessary rights to use and distribute your contributions. (To click through the agreement create an account on mbed.com and log in.)

--- a/DOXYGEN_FRONTPAGE.md
+++ b/DOXYGEN_FRONTPAGE.md
@@ -1,16 +1,15 @@
 #BLE API
 
-The BLE module within mbed OS offers a high level abstraction for using
+The BLE module within mbed OS offers a high abstraction level for using
 Bluetooth Low Energy on multiple platforms.
 
-This documentation describes the internal structure of mbed
-(BLE_API)[https://github.com/armmbed/ble]. It was automatically generated from
-specially formatted comment blocks in BLE_API's source code using Doxygen.
-(See http://www.stack.nl/~dimitri/doxygen/ for more information on Doxygen).
+This documentation describes the internal structure of the mbed
+[BLE API](https://github.com/armmbed/ble). It was automatically generated from
+specially formatted comment blocks in BLE API's source code using Doxygen (see http://www.stack.nl/~dimitri/doxygen/ for more information on Doxygen).
 
-For getting started with BLE on mbed, check our (introduction
-page)[https://docs.mbed.com/docs/ble-intros/en/latest/].
+For getting started with BLE on mbed, check our [introduction
+page](https://docs.mbed.com/docs/ble-intros/en/latest/).
 
-For mbed OS examples using BLE, check (this
-repository)[https://github.com/armmbed/ble-examples]. For mbed-classic
-examples, refer to (code under mbed.org)[https://developer.mbed.org/teams/Bluetooth-Low-Energy/code/].
+For mbed OS examples using BLE, check [this
+repository](https://github.com/armmbed/ble-examples). For mbed-classic
+examples, please refer to [code under mbed.org](https://developer.mbed.org/teams/Bluetooth-Low-Energy/code/).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This is the Github repo for the `BLE_API` used by developer.mbed.org. Please see the [mbed BLE Homepage](https://developer.mbed.org/teams/Bluetooth-Low-Energy/) for all documentation, code examples and general help.
 
 # Supported Services
-Supported GATT services and constantly being added and can be found in the (ble/services/)[https://github.com/ARMmbed/ble/tree/master/ble/services] folder.
+Supported GATT services and constantly being added and can be found in the [ble/services/](https://github.com/ARMmbed/ble/tree/master/ble/services) folder.
 
 Currently supported services include:
 * Battery

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This is the Github repo for the `BLE_API` used by developer.mbed.org. Please see the [mbed BLE Homepage](https://developer.mbed.org/teams/Bluetooth-Low-Energy/) for all documentation, code examples and general help.
 
 # Supported Services
-Supported GATT services and constantly being added and can be found in the (`ble/ble/services/`)[https://github.com/ARMmbed/ble/tree/master/ble/services] folder.
+Supported GATT services and constantly being added and can be found in the (ble/services/)[https://github.com/ARMmbed/ble/tree/master/ble/services] folder.
 
 Currently supported services include:
 * Battery

--- a/ble/blecommon.h
+++ b/ble/blecommon.h
@@ -22,9 +22,7 @@ extern "C" {
 #endif
 
 
-/** @defgroup BLE_UUID_VALUES assigned values for BLE UUIDs.
- * @{ */
-/* Generic UUIDs, applicable to all services. */
+/*! @brief Assigned values for BLE UUIDs. */
 enum {
     BLE_UUID_UNKNOWN                             = 0x0000, /**< Reserved UUID. */
     BLE_UUID_SERVICE_PRIMARY                     = 0x2800, /**< Primary Service. */
@@ -50,11 +48,10 @@ enum {
     BLE_UUID_GAP_CHARACTERISTIC_RECONN_ADDR      = 0x2A03, /**< Reconnection Address Characteristic. */
     BLE_UUID_GAP_CHARACTERISTIC_PPCP             = 0x2A04, /**< Peripheral Preferred Connection Parameters Characteristic. */
 };
-/** @} */
 
-/** @defgroup BLE_APPEARANCES Bluetooth appearance values.
+/*! Bluetooth appearance values.
  *  @note Retrieved from http://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.gap.appearance.xml
- * @{ */
+ */
 enum {
     BLE_APPEARANCE_UNKNOWN                             =    0, /**< Unknown. */
     BLE_APPEARANCE_GENERIC_PHONE                       =   64, /**< Generic Phone. */
@@ -106,13 +103,9 @@ enum {
     BLE_APPEARANCE_OUTDOOR_SPORTS_ACT_LOC_POD          = 5187, /**< Location Pod (Outdoor Sports Activity subtype). */
     BLE_APPEARANCE_OUTDOOR_SPORTS_ACT_LOC_AND_NAV_POD  = 5188, /**< Location and Navigation Pod (Outdoor Sports Activity subtype). */
 };
-/** @} */
 
-/**************************************************************************/
-/*!
-    \brief  Error codes for the BLE API
-*/
-/**************************************************************************/
+
+/*! @brief Error codes for the BLE API. */
 enum ble_error_t {
     BLE_ERROR_NONE                      = 0, /**< No error. */
     BLE_ERROR_BUFFER_OVERFLOW           = 1, /**< The requested action would cause a buffer overflow and has been aborted. */

--- a/doxygen/.gitignore
+++ b/doxygen/.gitignore
@@ -1,0 +1,2 @@
+# Ignore the generated Doxygen output
+/apidoc/

--- a/doxygen/Makefile
+++ b/doxygen/Makefile
@@ -1,0 +1,12 @@
+# Makefile used to generate the API documentation using Doxygen
+
+.PHONY: apidoc apidoc_clean
+
+all: apidoc
+
+apidoc:
+	mkdir -p apidoc
+	doxygen ble.doxyfile
+
+apidoc_clean:
+	rm -rf apidoc

--- a/doxygen/ble.doxyfile
+++ b/doxygen/ble.doxyfile
@@ -664,7 +664,7 @@ WARN_LOGFILE           =
 # directories like "/usr/src/myproject". Separate the files or directories
 # with spaces.
 
-INPUT                  = .
+INPUT                  = ../ble ../source ./
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding, which is
@@ -682,7 +682,7 @@ INPUT_ENCODING         = UTF-8
 # *.hxx *.hpp *.h++ *.idl *.odl *.cs *.php *.php3 *.inc *.m *.mm *.dox *.py
 # *.f90 *.f *.for *.vhd *.vhdl
 
-FILE_PATTERNS          = *.h *.cpp
+FILE_PATTERNS          = *.h *.cpp *.md
 
 # The RECURSIVE tag can be used to turn specify whether or not subdirectories
 # should be searched for input files as well. Possible values are YES and NO.

--- a/doxygen/main.md
+++ b/doxygen/main.md
@@ -1,4 +1,4 @@
-#BLE API
+# BLE API {#mainpage}
 
 The BLE module within mbed OS offers a high abstraction level for using
 Bluetooth Low Energy on multiple platforms.
@@ -13,3 +13,16 @@ page](https://docs.mbed.com/docs/ble-intros/en/latest/).
 For mbed OS examples using BLE, check [this
 repository](https://github.com/armmbed/ble-examples). For mbed-classic
 examples, please refer to [code under mbed.org](https://developer.mbed.org/teams/Bluetooth-Low-Energy/code/).
+
+## Supported Services
+
+Currently supported  services include:
+
+* [Battery](@ref BatteryService)
+* [Device Firmware Update (DFU)](@ref DFUService)
+* [Device Information](@ref DeviceInformationService)
+* [Health Thermometer](@ref HealthThermometerService)
+* [Heart Rate](@ref HeartRateService)
+* [UART](@ref UARTService)
+* [UriBeacon](@ref URIBeaconConfigService)
+* [iBeacon](@ref iBeacon)


### PR DESCRIPTION
@rgrover added Doxygen support in commits 04d10f65474c22480501ced491f4a32af746346f and f72edf4d503903c101c75843a9c3f32f8a2bbd44.
This is great! IMO, it is a must have for an API :smirk:

I refactored all Doxygen stuff to a specific folder (to keep some consistency, I did the same as [mbedtls](https://github.com/ARMmbed/mbedtls/tree/development/doxygen)) . I added a Makefile to generate the doc automatically and fix some typos (especially wrong Markdown syntax).

This is the very first Doxygen output and the documentation is not well formatted yet. A lot of polishing is needed... I am not native English speaker, so I cannot correct the doc or add Doxygen pages.

What we can do is publishing automatically the Doxygen documentation (for release versions) to `gh-page` so the doc is available online instantaneously (here is an example - https://tls.mbed.org/api/). I can do this job, please let me know if you are interested...