### PR TITLE
Separate the concept of minlen and len in GattAttr

### DIFF
--- a/ble/GattAttribute.h
+++ b/ble/GattAttribute.h
@@ -33,8 +33,8 @@ public:
      *              The UUID to use for this attribute.
      *  @param[in]  valuePtr
      *              The memory holding the initial value.
-     *  @param[in]  initialLen
-     *              The min length in bytes of this attribute's value.
+     *  @param[in]  len
+     *              The length in bytes of this attribute's value.
      *  @param[in]  maxLen
      *              The max length in bytes of this attribute's value.
      *
@@ -47,8 +47,8 @@ public:
      *
      *  @endcode
      */
-    GattAttribute(const UUID &uuid, uint8_t *valuePtr = NULL, uint16_t initialLen = 0, uint16_t maxLen = 0) :
-        _uuid(uuid), _valuePtr(valuePtr), _initialLen(initialLen), _lenMax(maxLen), _len(initialLen), _handle() {
+    GattAttribute(const UUID &uuid, uint8_t *valuePtr = NULL, uint16_t len = 0, uint16_t maxLen = 0) :
+        _uuid(uuid), _valuePtr(valuePtr), _lenMax(maxLen), _len(len), _handle() {
         /* Empty */
     }
 
@@ -56,7 +56,6 @@ public:
     Handle_t    getHandle(void)        const {return _handle;    }
     const UUID &getUUID(void)          const {return _uuid;      }
     uint16_t    getLength(void)        const {return _len;       }
-    uint16_t    getInitialLength(void) const {return _initialLen;}
     uint16_t    getMaxLength(void)     const {return _lenMax;    }
     uint16_t   *getLengthPtr(void)           {return &_len;      }
     void        setHandle(Handle_t id)       {_handle = id;      }
@@ -65,7 +64,6 @@ public:
 private:
     UUID      _uuid;        /* Characteristic UUID. */
     uint8_t  *_valuePtr;
-    uint16_t  _initialLen;  /* Initial length of the value. */
     uint16_t  _lenMax;      /* Maximum length of the value. */
     uint16_t  _len;         /* Current length of the value. */
     Handle_t  _handle;

--- a/ble/GattCharacteristic.h
+++ b/ble/GattCharacteristic.h
@@ -307,8 +307,8 @@ public:
      *              The memory holding the initial value. The value is copied
      *              into the stack when the enclosing service is added, and
      *              is thereafter maintained internally by the stack.
-     *  @param[in]  initialLen
-     *              The min length in bytes of this characteristic's value.
+     *  @param[in]  len
+     *              The length in bytes of this characteristic's value.
      *  @param[in]  maxLen
      *              The max length in bytes of this characteristic's value.
      *  @param[in]  props
@@ -321,19 +321,19 @@ public:
      *  @param[in]  numDescriptors
      *              The number of descriptors in the previous array.
      *
-     * @NOTE: If valuePtr == NULL, initialLength == 0, and properties == READ
+     * @NOTE: If valuePtr == NULL, length == 0, and properties == READ
      *        for the value attribute of a characteristic, then that particular
      *        characteristic may be considered optional and dropped while
      *        instantiating the service with the underlying BLE stack.
      */
     GattCharacteristic(const UUID    &uuid,
                        uint8_t       *valuePtr       = NULL,
-                       uint16_t       initialLen     = 0,
+                       uint16_t       len            = 0,
                        uint16_t       maxLen         = 0,
                        uint8_t        props          = BLE_GATT_CHAR_PROPERTIES_NONE,
                        GattAttribute *descriptors[]  = NULL,
                        unsigned       numDescriptors = 0) :
-        _valueAttribute(uuid, valuePtr, initialLen, maxLen),
+        _valueAttribute(uuid, valuePtr, len, maxLen),
         _properties(props),
         _requiredSecurity(SecurityManager::SECURITY_MODE_ENCRYPTION_OPEN_LINK),
         _descriptors(descriptors),


### PR DESCRIPTION
In previous versions of BLE_API the GattCharacteristic initLen parameter is named minLen as well. When the characteristic is committed to the SoftDevice the value of initial length is also used as the minimum length of the characteristic value. Furthermore, the test (max_length == min_length) is used to determine whether the characteristic value has variable length. This is slightly confusing and also causes problems if the user wishes to use a characteristic with variable length but the initial length is equal to max length.

To solve this problem the characteristic is now always committed to the SoftDevice as variable. Furthermore, the API only maintains the current length and the max length i.e. the field initialLen in the GattAttribute is removed. Finally, the constructor for the GattCharacteristic was modified to reflect these changes.

**NOTES:**
* This change requires updates to ble-nrf51822.
* Ideally we would like the characteristics to be declared as 'variable' only when necessary, but this requires changing the signature of the GattCharacteristic and GattAttribute constructures. Therefore, it will be part of a separate pull request.