### PR TITLE
Allow GattAttributes to have variable length

### DIFF
--- a/ble/GattAttribute.h
+++ b/ble/GattAttribute.h
@@ -37,6 +37,8 @@ public:
      *              The length in bytes of this attribute's value.
      *  @param[in]  maxLen
      *              The max length in bytes of this attribute's value.
+     *  @param[in]  hasVariableLen
+     *              Whether the attribute's value length changes overtime.
      *
      *  @section EXAMPLE
      *
@@ -47,25 +49,27 @@ public:
      *
      *  @endcode
      */
-    GattAttribute(const UUID &uuid, uint8_t *valuePtr = NULL, uint16_t len = 0, uint16_t maxLen = 0) :
-        _uuid(uuid), _valuePtr(valuePtr), _lenMax(maxLen), _len(len), _handle() {
+    GattAttribute(const UUID &uuid, uint8_t *valuePtr = NULL, uint16_t len = 0, uint16_t maxLen = 0, bool hasVariableLen = true) :
+        _uuid(uuid), _valuePtr(valuePtr), _lenMax(maxLen), _len(len), _hasVariableLen(hasVariableLen), _handle() {
         /* Empty */
     }
 
 public:
-    Handle_t    getHandle(void)        const {return _handle;    }
-    const UUID &getUUID(void)          const {return _uuid;      }
-    uint16_t    getLength(void)        const {return _len;       }
-    uint16_t    getMaxLength(void)     const {return _lenMax;    }
-    uint16_t   *getLengthPtr(void)           {return &_len;      }
-    void        setHandle(Handle_t id)       {_handle = id;      }
-    uint8_t    *getValuePtr(void)            {return _valuePtr;  }
+    Handle_t    getHandle(void)         const {return _handle;        }
+    const UUID &getUUID(void)           const {return _uuid;          }
+    uint16_t    getLength(void)         const {return _len;           }
+    uint16_t    getMaxLength(void)      const {return _lenMax;        }
+    uint16_t   *getLengthPtr(void)            {return &_len;          }
+    void        setHandle(Handle_t id)        {_handle = id;          }
+    uint8_t    *getValuePtr(void)             {return _valuePtr;      }
+    bool        hasVariableLength(void) const {return _hasVariableLen;}
 
 private:
-    UUID      _uuid;        /* Characteristic UUID. */
+    UUID      _uuid;           /* Characteristic UUID. */
     uint8_t  *_valuePtr;
-    uint16_t  _lenMax;      /* Maximum length of the value. */
-    uint16_t  _len;         /* Current length of the value. */
+    uint16_t  _lenMax;         /* Maximum length of the value. */
+    uint16_t  _len;            /* Current length of the value. */
+    bool      _hasVariableLen;
     Handle_t  _handle;
 
 private:

--- a/ble/GattCharacteristic.h
+++ b/ble/GattCharacteristic.h
@@ -312,7 +312,7 @@ public:
      *  @param[in]  maxLen
      *              The max length in bytes of this characteristic's value.
      *  @param[in]  hasVariableLen
-     *              Whether the attribute's value length changes overtime.
+     *              Whether the attribute's value length changes over time.
      *  @param[in]  props
      *              The 8-bit field containing the characteristic's properties.
      *  @param[in]  descriptors
@@ -483,7 +483,7 @@ public:
                                    GattAttribute *descriptors[]        = NULL,
                                    unsigned       numDescriptors       = 0) :
         GattCharacteristic(uuid, reinterpret_cast<uint8_t *>(valuePtr), sizeof(T), sizeof(T),
-                           BLE_GATT_CHAR_PROPERTIES_WRITE | additionalProperties, descriptors, numDescriptors, false) {
+                           BLE_GATT_CHAR_PROPERTIES_WRITE | additionalProperties, descriptors, numDescriptors) {
         /* empty */
     }
 };
@@ -497,7 +497,7 @@ public:
                                    GattAttribute *descriptors[]        = NULL,
                                    unsigned       numDescriptors       = 0) :
         GattCharacteristic(uuid, reinterpret_cast<uint8_t *>(valuePtr), sizeof(T), sizeof(T),
-                           BLE_GATT_CHAR_PROPERTIES_READ | BLE_GATT_CHAR_PROPERTIES_WRITE | additionalProperties, descriptors, numDescriptors, false) {
+                           BLE_GATT_CHAR_PROPERTIES_READ | BLE_GATT_CHAR_PROPERTIES_WRITE | additionalProperties, descriptors, numDescriptors) {
         /* empty */
     }
 };
@@ -511,7 +511,7 @@ public:
                                                       GattAttribute *descriptors[]        = NULL,
                                                       unsigned       numDescriptors       = 0) :
         GattCharacteristic(uuid, reinterpret_cast<uint8_t *>(valuePtr), sizeof(T) * NUM_ELEMENTS, sizeof(T) * NUM_ELEMENTS,
-                           BLE_GATT_CHAR_PROPERTIES_WRITE | additionalProperties, descriptors, numDescriptors, false) {
+                           BLE_GATT_CHAR_PROPERTIES_WRITE | additionalProperties, descriptors, numDescriptors) {
         /* empty */
     }
 };
@@ -539,7 +539,7 @@ public:
                                                       GattAttribute *descriptors[]        = NULL,
                                                       unsigned       numDescriptors       = 0) :
         GattCharacteristic(uuid, reinterpret_cast<uint8_t *>(valuePtr), sizeof(T) * NUM_ELEMENTS, sizeof(T) * NUM_ELEMENTS,
-                           BLE_GATT_CHAR_PROPERTIES_READ | BLE_GATT_CHAR_PROPERTIES_WRITE | additionalProperties, descriptors, numDescriptors, false) {
+                           BLE_GATT_CHAR_PROPERTIES_READ | BLE_GATT_CHAR_PROPERTIES_WRITE | additionalProperties, descriptors, numDescriptors) {
         /* empty */
     }
 };

--- a/ble/GattCharacteristic.h
+++ b/ble/GattCharacteristic.h
@@ -311,6 +311,8 @@ public:
      *              The length in bytes of this characteristic's value.
      *  @param[in]  maxLen
      *              The max length in bytes of this characteristic's value.
+     *  @param[in]  hasVariableLen
+     *              Whether the attribute's value length changes overtime.
      *  @param[in]  props
      *              The 8-bit field containing the characteristic's properties.
      *  @param[in]  descriptors
@@ -332,8 +334,9 @@ public:
                        uint16_t       maxLen         = 0,
                        uint8_t        props          = BLE_GATT_CHAR_PROPERTIES_NONE,
                        GattAttribute *descriptors[]  = NULL,
-                       unsigned       numDescriptors = 0) :
-        _valueAttribute(uuid, valuePtr, len, maxLen),
+                       unsigned       numDescriptors = 0,
+                       bool           hasVariableLen = true) :
+        _valueAttribute(uuid, valuePtr, len, maxLen, hasVariableLen),
         _properties(props),
         _requiredSecurity(SecurityManager::SECURITY_MODE_ENCRYPTION_OPEN_LINK),
         _descriptors(descriptors),

--- a/ble/GattCharacteristic.h
+++ b/ble/GattCharacteristic.h
@@ -469,7 +469,7 @@ public:
                                   GattAttribute *descriptors[]        = NULL,
                                   unsigned       numDescriptors       = 0) :
         GattCharacteristic(uuid, reinterpret_cast<uint8_t *>(valuePtr), sizeof(T), sizeof(T),
-                           BLE_GATT_CHAR_PROPERTIES_READ | additionalProperties, descriptors, numDescriptors) {
+                           BLE_GATT_CHAR_PROPERTIES_READ | additionalProperties, descriptors, numDescriptors, false) {
         /* empty */
     }
 };
@@ -483,7 +483,7 @@ public:
                                    GattAttribute *descriptors[]        = NULL,
                                    unsigned       numDescriptors       = 0) :
         GattCharacteristic(uuid, reinterpret_cast<uint8_t *>(valuePtr), sizeof(T), sizeof(T),
-                           BLE_GATT_CHAR_PROPERTIES_WRITE | additionalProperties, descriptors, numDescriptors) {
+                           BLE_GATT_CHAR_PROPERTIES_WRITE | additionalProperties, descriptors, numDescriptors, false) {
         /* empty */
     }
 };
@@ -497,7 +497,7 @@ public:
                                    GattAttribute *descriptors[]        = NULL,
                                    unsigned       numDescriptors       = 0) :
         GattCharacteristic(uuid, reinterpret_cast<uint8_t *>(valuePtr), sizeof(T), sizeof(T),
-                           BLE_GATT_CHAR_PROPERTIES_READ | BLE_GATT_CHAR_PROPERTIES_WRITE | additionalProperties, descriptors, numDescriptors) {
+                           BLE_GATT_CHAR_PROPERTIES_READ | BLE_GATT_CHAR_PROPERTIES_WRITE | additionalProperties, descriptors, numDescriptors, false) {
         /* empty */
     }
 };
@@ -511,7 +511,7 @@ public:
                                                       GattAttribute *descriptors[]        = NULL,
                                                       unsigned       numDescriptors       = 0) :
         GattCharacteristic(uuid, reinterpret_cast<uint8_t *>(valuePtr), sizeof(T) * NUM_ELEMENTS, sizeof(T) * NUM_ELEMENTS,
-                           BLE_GATT_CHAR_PROPERTIES_WRITE | additionalProperties, descriptors, numDescriptors) {
+                           BLE_GATT_CHAR_PROPERTIES_WRITE | additionalProperties, descriptors, numDescriptors, false) {
         /* empty */
     }
 };
@@ -525,7 +525,7 @@ public:
                                                      GattAttribute *descriptors[]        = NULL,
                                                      unsigned       numDescriptors       = 0) :
         GattCharacteristic(uuid, reinterpret_cast<uint8_t *>(valuePtr), sizeof(T) * NUM_ELEMENTS, sizeof(T) * NUM_ELEMENTS,
-                           BLE_GATT_CHAR_PROPERTIES_READ | additionalProperties, descriptors, numDescriptors) {
+                           BLE_GATT_CHAR_PROPERTIES_READ | additionalProperties, descriptors, numDescriptors, false) {
         /* empty */
     }
 };
@@ -539,7 +539,7 @@ public:
                                                       GattAttribute *descriptors[]        = NULL,
                                                       unsigned       numDescriptors       = 0) :
         GattCharacteristic(uuid, reinterpret_cast<uint8_t *>(valuePtr), sizeof(T) * NUM_ELEMENTS, sizeof(T) * NUM_ELEMENTS,
-                           BLE_GATT_CHAR_PROPERTIES_READ | BLE_GATT_CHAR_PROPERTIES_WRITE | additionalProperties, descriptors, numDescriptors) {
+                           BLE_GATT_CHAR_PROPERTIES_READ | BLE_GATT_CHAR_PROPERTIES_WRITE | additionalProperties, descriptors, numDescriptors, false) {
         /* empty */
     }
 };


### PR DESCRIPTION
Previously the concepts of initLength and lenth were clearly separated. However, this was at the cost of registering all characteristics in the SoftDevice as having variable length. Clearly, this is not the desired behaviour. Therefore, an additional field '_hasVariableLen' is added to the GattAttribute to address the problem. Also, the GattAttribute and GattCharacteristic constructors have been modified to take a boolean that sets '_hasVariableLen'.
@rgrover 