### PR TITLE
Extract Adress related types from Gap.h into BLEProtocol.h

### DIFF
--- a/ble/BLE.h
+++ b/ble/BLE.h
@@ -239,7 +239,7 @@ public:
      * ble.setAddress(...) should be replaced with
      * ble.gap().setAddress(...).
      */
-    ble_error_t setAddress(BLEProtocol::AddressType::Type type, const Gap::Address_t address) {
+    ble_error_t setAddress(BLEProtocol::AddressType_t type, const BLEProtocol::Address_t address) {
         return gap().setAddress(type, address);
     }
 
@@ -252,7 +252,7 @@ public:
      * ble.getAddress(...) should be replaced with
      * ble.gap().getAddress(...).
      */
-    ble_error_t getAddress(BLEProtocol::AddressType::Type *typeP, Gap::Address_t address) {
+    ble_error_t getAddress(BLEProtocol::AddressType_t *typeP, BLEProtocol::Address_t address) {
         return gap().getAddress(typeP, address);
     }
 
@@ -752,8 +752,8 @@ public:
      * ble.connect(...) should be replaced with
      * ble.gap().connect(...).
      */
-    ble_error_t connect(const Gap::Address_t           peerAddr,
-                        BLEProtocol::AddressType::Type peerAddrType = BLEProtocol::AddressType::RANDOM_STATIC,
+    ble_error_t connect(const BLEProtocol::Address_t   peerAddr,
+                        BLEProtocol::AddressType_t     peerAddrType = BLEProtocol::AddressType::RANDOM_STATIC,
                         const Gap::ConnectionParams_t *connectionParams = NULL,
                         const GapScanningParams       *scanParams = NULL) {
         return gap().connect(peerAddr, peerAddrType, connectionParams, scanParams);

--- a/ble/BLE.h
+++ b/ble/BLE.h
@@ -196,7 +196,7 @@ public:
      * directly, as it returns references to singletons.
      *
      * @param[in] id
-     *              Instance-ID. This should be less than NUM_INSTANCES 
+     *              Instance-ID. This should be less than NUM_INSTANCES
      *              for the returned BLE singleton to be useful.
      *
      * @return a reference to a single object.
@@ -239,7 +239,7 @@ public:
      * ble.setAddress(...) should be replaced with
      * ble.gap().setAddress(...).
      */
-    ble_error_t setAddress(Gap::AddressType_t type, const Gap::Address_t address) {
+    ble_error_t setAddress(BLEProtocol::AddressType::Type type, const Gap::Address_t address) {
         return gap().setAddress(type, address);
     }
 
@@ -252,7 +252,7 @@ public:
      * ble.getAddress(...) should be replaced with
      * ble.gap().getAddress(...).
      */
-    ble_error_t getAddress(Gap::AddressType_t *typeP, Gap::Address_t address) {
+    ble_error_t getAddress(BLEProtocol::AddressType::Type *typeP, Gap::Address_t address) {
         return gap().getAddress(typeP, address);
     }
 
@@ -753,7 +753,7 @@ public:
      * ble.gap().connect(...).
      */
     ble_error_t connect(const Gap::Address_t           peerAddr,
-                        Gap::AddressType_t             peerAddrType = Gap::ADDR_TYPE_RANDOM_STATIC,
+                        BLEProtocol::AddressType::Type peerAddrType = BLEProtocol::AddressType::RANDOM_STATIC,
                         const Gap::ConnectionParams_t *connectionParams = NULL,
                         const GapScanningParams       *scanParams = NULL) {
         return gap().connect(peerAddr, peerAddrType, connectionParams, scanParams);
@@ -773,7 +773,7 @@ public:
     }
 
     /**
-     * This call initiates the disconnection procedure, and its completion 
+     * This call initiates the disconnection procedure, and its completion
      * is communicated to the application with an invocation of the
      * onDisconnection callback.
      *
@@ -1407,7 +1407,7 @@ public:
     /**
      * Set up a callback for when the passkey needs to be displayed on a
      * peripheral with DISPLAY capability. This happens when security is
-     * configured to prevent Man-In-The-Middle attacks, and the peers need to exchange 
+     * configured to prevent Man-In-The-Middle attacks, and the peers need to exchange
      * a passkey (or PIN) to authenticate the connection
      * attempt.
      *

--- a/ble/BLEProtocol.h
+++ b/ble/BLEProtocol.h
@@ -26,14 +26,13 @@
 namespace BLEProtocol {
     /**< Address-type for Protocol addresses. */
     struct AddressType { /* Adding a struct to encapsulate the contained enumeration
-                            * prevents polluting the BLEProtocol namespace with the
-                            * enumerated values. It also allows type-aliases for the
-                            * enumeration while retaining the enumerated values. i.e.
-                            *
-                            * doing:
-                            *       typedef AddressType_t AliasedType_t;
-                            * would allow the use of AliasedType_t::PUBLIC in code.
-                            */
+                          * prevents polluting the BLEProtocol namespace with the
+                          * enumerated values. It also allows type-aliases for the
+                          * enumeration while retaining the enumerated values. i.e.
+                          *
+                          * doing:
+                          *       typedef AddressType_t AliasedType_t;
+                          * would allow the use of AliasedType_t::PUBLIC in code. */
         enum Type {
             PUBLIC = 0,
             RANDOM_STATIC,
@@ -41,9 +40,10 @@ namespace BLEProtocol {
             RANDOM_PRIVATE_NON_RESOLVABLE
         };
     };
+    typedef AddressType::Type AddressType_t; /**< Alias for AddressType::Type */
 
-    static const size_t ADDR_LEN = 6;    /**< Length (in octets) of the BLE MAC address. */
-    typedef uint8_t Address_t[ADDR_LEN]; /**< 48-bit address, in LSB format. */
+    static const size_t ADDR_LEN = 6;        /**< Length (in octets) of the BLE MAC address. */
+    typedef uint8_t Address_t[ADDR_LEN];     /**< 48-bit address, in LSB format. */
 };
 
 #endif /* __BLE_PROTOCOL_H__ */

--- a/ble/BLEProtocol.h
+++ b/ble/BLEProtocol.h
@@ -1,0 +1,49 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __BLE_PROTOCOL_H__
+#define __BLE_PROTOCOL_H__
+
+#include <stddef.h>
+#include <stdint.h>
+
+/**
+ * A common container for types and constants used everywhere in BLE API.
+ */
+struct BLEProtocol {
+    /**< Address-type for Protocol addresses. */
+    struct AddressType { /* Adding a struct to encapsulate the contained enumeration
+                            * prevents polluting the BLEProtocol namespace with the
+                            * enumerated values. It also allows type-aliases for the
+                            * enumeration while retaining the enumerated values. i.e.
+                            *
+                            * doing:
+                            *       typedef AddressType_t AliasedType_t;
+                            * would allow the use of AliasedType_t::PUBLIC in code.
+                            */
+        enum Type {
+            PUBLIC = 0,
+            RANDOM_STATIC,
+            RANDOM_PRIVATE_RESOLVABLE,
+            RANDOM_PRIVATE_NON_RESOLVABLE
+        };
+    };
+
+    static const size_t ADDR_LEN = 6;    /**< Length (in octets) of the BLE MAC address. */
+    typedef uint8_t Address_t[ADDR_LEN]; /**< 48-bit address, in LSB format. */
+};
+
+#endif /* __BLE_PROTOCOL_H__ */

--- a/ble/BLEProtocol.h
+++ b/ble/BLEProtocol.h
@@ -21,9 +21,9 @@
 #include <stdint.h>
 
 /**
- * A common container for types and constants used everywhere in BLE API.
+ * A common namespace for types and constants used everywhere in BLE API.
  */
-struct BLEProtocol {
+namespace BLEProtocol {
     /**< Address-type for Protocol addresses. */
     struct AddressType { /* Adding a struct to encapsulate the contained enumeration
                             * prevents polluting the BLEProtocol namespace with the

--- a/ble/Gap.h
+++ b/ble/Gap.h
@@ -38,15 +38,15 @@ class Gap {
 public:
     /**
      * Address-type for BLEProtocol addresses.
-     * @note: deprecated. Use BLEProtocol::AddressType::Type instead.
+     * @note: deprecated. Use BLEProtocol::AddressType_t instead.
      */
-    typedef BLEProtocol::AddressType::Type AddressType_t;
+    typedef BLEProtocol::AddressType_t AddressType_t;
 
     /**
      * Address-type for BLEProtocol addresses.
-     * @note: deprecated. Use BLEProtocol::AddressType::Type instead.
+     * @note: deprecated. Use BLEProtocol::AddressType_t instead.
      */
-    typedef BLEProtocol::AddressType::Type addr_type_t;
+    typedef BLEProtocol::AddressType_t addr_type_t;
 
     static const unsigned ADDR_LEN = BLEProtocol::ADDR_LEN; /**< Length (in octets) of the BLE MAC address. */
     typedef BLEProtocol::Address_t Address_t; /**< 48-bit address, LSB format. @Note: Deprecated. Use BLEProtocol::Address_t instead. */
@@ -107,21 +107,21 @@ public:
     typedef FunctionPointerWithContext<const AdvertisementCallbackParams_t *> AdvertisementReportCallback_t;
 
     struct ConnectionCallbackParams_t {
-        Handle_t                        handle;
-        Role_t                          role;
-        BLEProtocol::AddressType::Type  peerAddrType;
-        Address_t                       peerAddr;
-        BLEProtocol::AddressType::Type  ownAddrType;
-        Address_t                       ownAddr;
-        const ConnectionParams_t       *connectionParams;
+        Handle_t                    handle;
+        Role_t                      role;
+        BLEProtocol::AddressType_t  peerAddrType;
+        Address_t                   peerAddr;
+        BLEProtocol::AddressType_t  ownAddrType;
+        Address_t                   ownAddr;
+        const ConnectionParams_t   *connectionParams;
 
-        ConnectionCallbackParams_t(Handle_t                        handleIn,
-                                   Role_t                          roleIn,
-                                   BLEProtocol::AddressType::Type  peerAddrTypeIn,
-                                   const uint8_t                  *peerAddrIn,
-                                   BLEProtocol::AddressType::Type  ownAddrTypeIn,
-                                   const uint8_t                  *ownAddrIn,
-                                   const ConnectionParams_t       *connectionParamsIn) :
+        ConnectionCallbackParams_t(Handle_t                    handleIn,
+                                   Role_t                      roleIn,
+                                   BLEProtocol::AddressType_t  peerAddrTypeIn,
+                                   const uint8_t              *peerAddrIn,
+                                   BLEProtocol::AddressType_t  ownAddrTypeIn,
+                                   const uint8_t              *ownAddrIn,
+                                   const ConnectionParams_t   *connectionParamsIn) :
             handle(handleIn),
             role(roleIn),
             peerAddrType(peerAddrTypeIn),
@@ -171,7 +171,7 @@ public:
      *
      * @return BLE_ERROR_NONE on success.
      */
-    virtual ble_error_t setAddress(BLEProtocol::AddressType::Type type, const Address_t address) {
+    virtual ble_error_t setAddress(BLEProtocol::AddressType_t type, const Address_t address) {
         /* avoid compiler warnings about unused variables */
         (void)type;
         (void)address;
@@ -184,7 +184,7 @@ public:
      *
      * @return BLE_ERROR_NONE on success.
      */
-    virtual ble_error_t getAddress(BLEProtocol::AddressType::Type *typeP, Address_t address) {
+    virtual ble_error_t getAddress(BLEProtocol::AddressType_t *typeP, Address_t address) {
         /* Avoid compiler warnings about unused variables. */
         (void)typeP;
         (void)address;
@@ -243,10 +243,10 @@ public:
      *     successfully. The connectionCallChain (if set) will be invoked upon
      *     a connection event.
      */
-    virtual ble_error_t connect(const Address_t                 peerAddr,
-                                BLEProtocol::AddressType::Type  peerAddrType,
-                                const ConnectionParams_t       *connectionParams,
-                                const GapScanningParams        *scanParams) {
+    virtual ble_error_t connect(const Address_t             peerAddr,
+                                BLEProtocol::AddressType_t  peerAddrType,
+                                const ConnectionParams_t   *connectionParams,
+                                const GapScanningParams    *scanParams) {
         /* Avoid compiler warnings about unused variables. */
         (void)peerAddr;
         (void)peerAddrType;
@@ -1012,13 +1012,13 @@ protected:
 
     /* Entry points for the underlying stack to report events back to the user. */
 public:
-    void processConnectionEvent(Handle_t                        handle,
-                                Role_t                          role,
-                                BLEProtocol::AddressType::Type  peerAddrType,
-                                const Address_t                 peerAddr,
-                                BLEProtocol::AddressType::Type  ownAddrType,
-                                const Address_t                 ownAddr,
-                                const ConnectionParams_t       *connectionParams) {
+    void processConnectionEvent(Handle_t                    handle,
+                                Role_t                      role,
+                                BLEProtocol::AddressType_t  peerAddrType,
+                                const Address_t             peerAddr,
+                                BLEProtocol::AddressType_t  ownAddrType,
+                                const Address_t             ownAddr,
+                                const ConnectionParams_t   *connectionParams) {
         state.connected = 1;
         ConnectionCallbackParams_t callbackParams(handle, role, peerAddrType, peerAddr, ownAddrType, ownAddr, connectionParams);
         connectionCallChain.call(&callbackParams);

--- a/ble/Gap.h
+++ b/ble/Gap.h
@@ -17,6 +17,7 @@
 #ifndef __GAP_H__
 #define __GAP_H__
 
+#include "ble/BLEProtocol.h"
 #include "GapAdvertisingData.h"
 #include "GapAdvertisingParams.h"
 #include "GapScanningParams.h"
@@ -30,19 +31,28 @@ class GapScanningParams;
 class GapAdvertisingData;
 
 class Gap {
+    /*
+     * DEPRECATION ALERT: all of the APIs in this `public` block are deprecated.
+     * They have been relocated to the class BLEProtocol.
+     */
 public:
-    enum AddressType_t {
-        ADDR_TYPE_PUBLIC = 0,
-        ADDR_TYPE_RANDOM_STATIC,
-        ADDR_TYPE_RANDOM_PRIVATE_RESOLVABLE,
-        ADDR_TYPE_RANDOM_PRIVATE_NON_RESOLVABLE
-    };
-    typedef enum AddressType_t addr_type_t; /* @Note: Deprecated. Use AddressType_t instead. */
+    /**
+     * Address-type for BLEProtocol addresses.
+     * @note: deprecated. Use BLEProtocol::AddressType::Type instead.
+     */
+    typedef BLEProtocol::AddressType::Type AddressType_t;
 
-    static const unsigned ADDR_LEN = 6;
-    typedef uint8_t Address_t[ADDR_LEN]; /* 48-bit address, LSB format. */
-    typedef Address_t address_t;         /* @Note: Deprecated. Use Address_t instead. */
+    /**
+     * Address-type for BLEProtocol addresses.
+     * @note: deprecated. Use BLEProtocol::AddressType::Type instead.
+     */
+    typedef BLEProtocol::AddressType::Type addr_type_t;
 
+    static const unsigned ADDR_LEN = BLEProtocol::ADDR_LEN; /**< Length (in octets) of the BLE MAC address. */
+    typedef BLEProtocol::Address_t Address_t; /**< 48-bit address, LSB format. @Note: Deprecated. Use BLEProtocol::Address_t instead. */
+    typedef BLEProtocol::Address_t address_t; /**< 48-bit address, LSB format. @Note: Deprecated. Use BLEProtocol::Address_t instead. */
+
+public:
     enum TimeoutSource_t {
         TIMEOUT_SRC_ADVERTISING      = 0x00, /**< Advertising timeout. */
         TIMEOUT_SRC_SECURITY_REQUEST = 0x01, /**< Security request timeout. */
@@ -97,21 +107,21 @@ public:
     typedef FunctionPointerWithContext<const AdvertisementCallbackParams_t *> AdvertisementReportCallback_t;
 
     struct ConnectionCallbackParams_t {
-        Handle_t      handle;
-        Role_t        role;
-        AddressType_t peerAddrType;
-        Address_t     peerAddr;
-        AddressType_t ownAddrType;
-        Address_t     ownAddr;
-        const ConnectionParams_t *connectionParams;
+        Handle_t                        handle;
+        Role_t                          role;
+        BLEProtocol::AddressType::Type  peerAddrType;
+        Address_t                       peerAddr;
+        BLEProtocol::AddressType::Type  ownAddrType;
+        Address_t                       ownAddr;
+        const ConnectionParams_t       *connectionParams;
 
-        ConnectionCallbackParams_t(Handle_t       handleIn,
-                                   Role_t         roleIn,
-                                   AddressType_t  peerAddrTypeIn,
-                                   const uint8_t *peerAddrIn,
-                                   AddressType_t  ownAddrTypeIn,
-                                   const uint8_t *ownAddrIn,
-                                   const ConnectionParams_t *connectionParamsIn) :
+        ConnectionCallbackParams_t(Handle_t                        handleIn,
+                                   Role_t                          roleIn,
+                                   BLEProtocol::AddressType::Type  peerAddrTypeIn,
+                                   const uint8_t                  *peerAddrIn,
+                                   BLEProtocol::AddressType::Type  ownAddrTypeIn,
+                                   const uint8_t                  *ownAddrIn,
+                                   const ConnectionParams_t       *connectionParamsIn) :
             handle(handleIn),
             role(roleIn),
             peerAddrType(peerAddrTypeIn),
@@ -161,7 +171,7 @@ public:
      *
      * @return BLE_ERROR_NONE on success.
      */
-    virtual ble_error_t setAddress(AddressType_t type, const Address_t address) {
+    virtual ble_error_t setAddress(BLEProtocol::AddressType::Type type, const Address_t address) {
         /* avoid compiler warnings about unused variables */
         (void)type;
         (void)address;
@@ -174,7 +184,7 @@ public:
      *
      * @return BLE_ERROR_NONE on success.
      */
-    virtual ble_error_t getAddress(AddressType_t *typeP, Address_t address) {
+    virtual ble_error_t getAddress(BLEProtocol::AddressType::Type *typeP, Address_t address) {
         /* Avoid compiler warnings about unused variables. */
         (void)typeP;
         (void)address;
@@ -233,10 +243,10 @@ public:
      *     successfully. The connectionCallChain (if set) will be invoked upon
      *     a connection event.
      */
-    virtual ble_error_t connect(const Address_t           peerAddr,
-                                Gap::AddressType_t        peerAddrType,
-                                const ConnectionParams_t *connectionParams,
-                                const GapScanningParams  *scanParams) {
+    virtual ble_error_t connect(const Address_t                 peerAddr,
+                                BLEProtocol::AddressType::Type  peerAddrType,
+                                const ConnectionParams_t       *connectionParams,
+                                const GapScanningParams        *scanParams) {
         /* Avoid compiler warnings about unused variables. */
         (void)peerAddr;
         (void)peerAddrType;
@@ -1002,13 +1012,13 @@ protected:
 
     /* Entry points for the underlying stack to report events back to the user. */
 public:
-    void processConnectionEvent(Handle_t                  handle,
-                                Role_t                    role,
-                                AddressType_t             peerAddrType,
-                                const Address_t           peerAddr,
-                                AddressType_t             ownAddrType,
-                                const Address_t           ownAddr,
-                                const ConnectionParams_t *connectionParams) {
+    void processConnectionEvent(Handle_t                        handle,
+                                Role_t                          role,
+                                BLEProtocol::AddressType::Type  peerAddrType,
+                                const Address_t                 peerAddr,
+                                BLEProtocol::AddressType::Type  ownAddrType,
+                                const Address_t                 ownAddr,
+                                const ConnectionParams_t       *connectionParams) {
         state.connected = 1;
         ConnectionCallbackParams_t callbackParams(handle, role, peerAddrType, peerAddr, ownAddrType, ownAddr, connectionParams);
         connectionCallChain.call(&callbackParams);

--- a/ble/Gap.h
+++ b/ble/Gap.h
@@ -97,12 +97,12 @@ public:
     };
 
     struct AdvertisementCallbackParams_t {
-        Address_t            peerAddr;
-        int8_t               rssi;
-        bool                 isScanResponse;
-        GapAdvertisingParams::AdvertisingType_t type;
-        uint8_t              advertisingDataLen;
-        const uint8_t       *advertisingData;
+        BLEProtocol::Address_t                   peerAddr;
+        int8_t                                   rssi;
+        bool                                     isScanResponse;
+        GapAdvertisingParams::AdvertisingType_t  type;
+        uint8_t                                  advertisingDataLen;
+        const uint8_t                           *advertisingData;
     };
     typedef FunctionPointerWithContext<const AdvertisementCallbackParams_t *> AdvertisementReportCallback_t;
 
@@ -110,9 +110,9 @@ public:
         Handle_t                    handle;
         Role_t                      role;
         BLEProtocol::AddressType_t  peerAddrType;
-        Address_t                   peerAddr;
+        BLEProtocol::Address_t      peerAddr;
         BLEProtocol::AddressType_t  ownAddrType;
-        Address_t                   ownAddr;
+        BLEProtocol::Address_t      ownAddr;
         const ConnectionParams_t   *connectionParams;
 
         ConnectionCallbackParams_t(Handle_t                    handleIn,
@@ -167,11 +167,11 @@ public:
 public:
     /**
      * Set the BTLE MAC address and type. Please note that the address format is
-     * least significant byte first (LSB). Please refer to Address_t.
+     * least significant byte first (LSB). Please refer to BLEProtocol::Address_t.
      *
      * @return BLE_ERROR_NONE on success.
      */
-    virtual ble_error_t setAddress(BLEProtocol::AddressType_t type, const Address_t address) {
+    virtual ble_error_t setAddress(BLEProtocol::AddressType_t type, const BLEProtocol::Address_t address) {
         /* avoid compiler warnings about unused variables */
         (void)type;
         (void)address;
@@ -184,7 +184,7 @@ public:
      *
      * @return BLE_ERROR_NONE on success.
      */
-    virtual ble_error_t getAddress(BLEProtocol::AddressType_t *typeP, Address_t address) {
+    virtual ble_error_t getAddress(BLEProtocol::AddressType_t *typeP, BLEProtocol::Address_t address) {
         /* Avoid compiler warnings about unused variables. */
         (void)typeP;
         (void)address;
@@ -243,10 +243,10 @@ public:
      *     successfully. The connectionCallChain (if set) will be invoked upon
      *     a connection event.
      */
-    virtual ble_error_t connect(const Address_t             peerAddr,
-                                BLEProtocol::AddressType_t  peerAddrType,
-                                const ConnectionParams_t   *connectionParams,
-                                const GapScanningParams    *scanParams) {
+    virtual ble_error_t connect(const BLEProtocol::Address_t  peerAddr,
+                                BLEProtocol::AddressType_t    peerAddrType,
+                                const ConnectionParams_t     *connectionParams,
+                                const GapScanningParams      *scanParams) {
         /* Avoid compiler warnings about unused variables. */
         (void)peerAddr;
         (void)peerAddrType;
@@ -1012,13 +1012,13 @@ protected:
 
     /* Entry points for the underlying stack to report events back to the user. */
 public:
-    void processConnectionEvent(Handle_t                    handle,
-                                Role_t                      role,
-                                BLEProtocol::AddressType_t  peerAddrType,
-                                const Address_t             peerAddr,
-                                BLEProtocol::AddressType_t  ownAddrType,
-                                const Address_t             ownAddr,
-                                const ConnectionParams_t   *connectionParams) {
+    void processConnectionEvent(Handle_t                      handle,
+                                Role_t                        role,
+                                BLEProtocol::AddressType_t    peerAddrType,
+                                const BLEProtocol::Address_t  peerAddr,
+                                BLEProtocol::AddressType_t    ownAddrType,
+                                const BLEProtocol::Address_t  ownAddr,
+                                const ConnectionParams_t     *connectionParams) {
         state.connected = 1;
         ConnectionCallbackParams_t callbackParams(handle, role, peerAddrType, peerAddr, ownAddrType, ownAddr, connectionParams);
         connectionCallChain.call(&callbackParams);
@@ -1030,12 +1030,12 @@ public:
         disconnectionCallChain.call(&callbackParams);
     }
 
-    void processAdvertisementReport(const Address_t    peerAddr,
-                                    int8_t             rssi,
-                                    bool               isScanResponse,
+    void processAdvertisementReport(const BLEProtocol::Address_t             peerAddr,
+                                    int8_t                                   rssi,
+                                    bool                                     isScanResponse,
                                     GapAdvertisingParams::AdvertisingType_t  type,
-                                    uint8_t            advertisingDataLen,
-                                    const uint8_t     *advertisingData) {
+                                    uint8_t                                  advertisingDataLen,
+                                    const uint8_t                           *advertisingData) {
         AdvertisementCallbackParams_t params;
         memcpy(params.peerAddr, peerAddr, ADDR_LEN);
         params.rssi               = rssi;


### PR DESCRIPTION
While adding support for white-listing, I realized that a lot of core types, such as Address_t, are currently residing in Gap.h but are more abstract than Gap. They should be abstracted out of Gap otherwise they will result in circular dependencies.

I've also taken the opportunity to cleanup the types and add some documentation.
 
internal-ref: IOTSFW-1416
@pan- @marcuschangarm @andresag01 @LiyouZhou 