### PR TITLE
transparenly support existing applications which may have used Gap::ADDR_TYPE_*

### DIFF
--- a/ble/Gap.h
+++ b/ble/Gap.h
@@ -46,6 +46,12 @@ public:
     /**
      * Address-type for BLEProtocol addresses.
      * @note: deprecated. Use BLEProtocol::AddressType_t instead.
+     */
+    typedef BLEProtocol::AddressType_t addr_type_t;
+
+    /**
+     * Address-type for BLEProtocol addresses.
+     * @note: deprecated. Use BLEProtocol::AddressType_t instead.
      *
      * DEPRECATION ALERT: The following constants have been left in their
      * deprecated state to transparenly support existing applications which may
@@ -57,12 +63,6 @@ public:
         ADDR_TYPE_RANDOM_PRIVATE_RESOLVABLE     = BLEProtocol::AddressType::RANDOM_PRIVATE_RESOLVABLE,
         ADDR_TYPE_RANDOM_PRIVATE_NON_RESOLVABLE = BLEProtocol::AddressType::RANDOM_PRIVATE_NON_RESOLVABLE
     };
-
-    /**
-     * Address-type for BLEProtocol addresses.
-     * @note: deprecated. Use BLEProtocol::AddressType_t instead.
-     */
-    typedef BLEProtocol::AddressType_t addr_type_t;
 
     static const unsigned ADDR_LEN = BLEProtocol::ADDR_LEN; /**< Length (in octets) of the BLE MAC address. */
     typedef BLEProtocol::Address_t Address_t; /**< 48-bit address, LSB format. @Note: Deprecated. Use BLEProtocol::Address_t instead. */

--- a/ble/Gap.h
+++ b/ble/Gap.h
@@ -39,15 +39,23 @@ public:
     /**
      * Address-type for BLEProtocol addresses.
      *
-     * @note: deprecated. Use BLEProtocol::AddressType_t instead. This declaration will soon be changed to:
-     *     typedef BLEProtocol::AddressType_t AddressType_t;
-     * It has been left in this current state to transparenly support existing applications which may have used Gap::ADDR_TYPE_*.
+     * @note: deprecated. Use BLEProtocol::AddressType_t instead.
      */
-    enum AddressType_t {
-        ADDR_TYPE_PUBLIC = BLEProtocol::AddressType::PUBLIC,
-        ADDR_TYPE_RANDOM_STATIC,
-        ADDR_TYPE_RANDOM_PRIVATE_RESOLVABLE,
-        ADDR_TYPE_RANDOM_PRIVATE_NON_RESOLVABLE
+    typedef BLEProtocol::AddressType_t AddressType_t;
+
+    /**
+     * Address-type for BLEProtocol addresses.
+     * @note: deprecated. Use BLEProtocol::AddressType_t instead.
+     *
+     * DEPRECATION ALERT: The following constants have been left in their
+     * deprecated state to transparenly support existing applications which may
+     * have used Gap::ADDR_TYPE_*.
+     */
+    enum {
+        ADDR_TYPE_PUBLIC                        = BLEProtocol::AddressType::PUBLIC,
+        ADDR_TYPE_RANDOM_STATIC                 = BLEProtocol::AddressType::RANDOM_STATIC,
+        ADDR_TYPE_RANDOM_PRIVATE_RESOLVABLE     = BLEProtocol::AddressType::RANDOM_PRIVATE_RESOLVABLE,
+        ADDR_TYPE_RANDOM_PRIVATE_NON_RESOLVABLE = BLEProtocol::AddressType::RANDOM_PRIVATE_NON_RESOLVABLE
     };
 
     /**

--- a/ble/Gap.h
+++ b/ble/Gap.h
@@ -38,9 +38,17 @@ class Gap {
 public:
     /**
      * Address-type for BLEProtocol addresses.
-     * @note: deprecated. Use BLEProtocol::AddressType_t instead.
+     *
+     * @note: deprecated. Use BLEProtocol::AddressType_t instead. This declaration will soon be changed to:
+     *     typedef BLEProtocol::AddressType_t AddressType_t;
+     * It has been left in this current state to transparenly support existing applications which may have used Gap::ADDR_TYPE_*.
      */
-    typedef BLEProtocol::AddressType_t AddressType_t;
+    enum AddressType_t {
+        ADDR_TYPE_PUBLIC = BLEProtocol::AddressType::PUBLIC,
+        ADDR_TYPE_RANDOM_STATIC,
+        ADDR_TYPE_RANDOM_PRIVATE_RESOLVABLE,
+        ADDR_TYPE_RANDOM_PRIVATE_NON_RESOLVABLE
+    };
 
     /**
      * Address-type for BLEProtocol addresses.


### PR DESCRIPTION
@pan- 