### PR TITLE
Move appearance enum to BLEProtocol

### DIFF
--- a/ble/BLE.h
+++ b/ble/BLE.h
@@ -410,7 +410,7 @@ public:
      * ble.accumulateAdvertisingPayload(appearance) should be replaced with
      * ble.gap().accumulateAdvertisingPayload(appearance).
      */
-    ble_error_t accumulateAdvertisingPayload(GapAdvertisingData::Appearance app) {
+    ble_error_t accumulateAdvertisingPayload(BLEProtocol::AppearanceType_t app) {
         return gap().accumulateAdvertisingPayload(app);
     }
 
@@ -915,7 +915,7 @@ public:
      * ble.setAppearance() should be replaced with
      * ble.gap().setAppearance().
      */
-    ble_error_t setAppearance(GapAdvertisingData::Appearance appearance) {
+    ble_error_t setAppearance(BLEProtocol::AppearanceType_t appearance) {
         return gap().setAppearance(appearance);
     }
 
@@ -929,7 +929,7 @@ public:
      * ble.getAppearance() should be replaced with
      * ble.gap().getAppearance().
      */
-    ble_error_t getAppearance(GapAdvertisingData::Appearance *appearanceP) {
+    ble_error_t getAppearance(BLEProtocol::AppearanceType_t *appearanceP) {
         return gap().getAppearance(appearanceP);
     }
 

--- a/ble/BLEProtocol.h
+++ b/ble/BLEProtocol.h
@@ -97,6 +97,7 @@ namespace BLEProtocol {
             PULSE_OXIMETER_GENERIC                         = 3136,  /**< Generic Pulse Oximeter. */
             PULSE_OXIMETER_FINGERTIP                       = 3137,  /**< Fingertip Pulse Oximeter. */
             PULSE_OXIMETER_WRIST_WORN                      = 3138,  /**< Wrist Worn Pulse Oximeter. */
+            GENERIC_WEIGHT_SCALE                           = 3200,  /**< Generic Weight Scale */
             OUTDOOR_GENERIC                                = 5184,  /**< Generic Outdoor. */
             OUTDOOR_LOCATION_DISPLAY_DEVICE                = 5185,  /**< Outdoor Location Display Device. */
             OUTDOOR_LOCATION_AND_NAVIGATION_DISPLAY_DEVICE = 5186,  /**< Outdoor Location and Navigation Display Device. */

--- a/ble/BLEProtocol.h
+++ b/ble/BLEProtocol.h
@@ -44,6 +44,67 @@ namespace BLEProtocol {
 
     static const size_t ADDR_LEN = 6;        /**< Length (in octets) of the BLE MAC address. */
     typedef uint8_t Address_t[ADDR_LEN];     /**< 48-bit address, in LSB format. */
+
+    /**
+     *  A list of values for the APPEARANCE AD Type, which describes the
+     *  physical shape or appearance of the device. Retrieved from:
+     *      - Bluetooth Core Specification Supplement, Part A, Section 1.12
+     *      - Bluetooth Core Specification 4.0 (Vol. 3), Part C, Section 12.2
+     *      - https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.gap.appearance.xml
+     */
+    struct AppearanceType {
+        enum Type {
+            UNKNOWN                                        = 0,     /**< Unknown or unspecified appearance type. */
+            GENERIC_PHONE                                  = 64,    /**< Generic Phone. */
+            GENERIC_COMPUTER                               = 128,   /**< Generic Computer. */
+            GENERIC_WATCH                                  = 192,   /**< Generic Watch. */
+            WATCH_SPORTS_WATCH                             = 193,   /**< Sports Watch. */
+            GENERIC_CLOCK                                  = 256,   /**< Generic Clock. */
+            GENERIC_DISPLAY                                = 320,   /**< Generic Display. */
+            GENERIC_REMOTE_CONTROL                         = 384,   /**< Generic Remote Control. */
+            GENERIC_EYE_GLASSES                            = 448,   /**< Generic Eye Glasses. */
+            GENERIC_TAG                                    = 512,   /**< Generic Tag. */
+            GENERIC_KEYRING                                = 576,   /**< Generic Keyring. */
+            GENERIC_MEDIA_PLAYER                           = 640,   /**< Generic Media Player. */
+            GENERIC_BARCODE_SCANNER                        = 704,   /**< Generic Barcode Scanner. */
+            GENERIC_THERMOMETER                            = 768,   /**< Generic Thermometer. */
+            THERMOMETER_EAR                                = 769,   /**< Ear Thermometer. */
+            GENERIC_HEART_RATE_SENSOR                      = 832,   /**< Generic Heart Rate Sensor. */
+            HEART_RATE_SENSOR_HEART_RATE_BELT              = 833,   /**< Belt Heart Rate Sensor. */
+            GENERIC_BLOOD_PRESSURE                         = 896,   /**< Generic Blood Pressure. */
+            BLOOD_PRESSURE_ARM                             = 897,   /**< Arm Blood Pressure. */
+            BLOOD_PRESSURE_WRIST                           = 898,   /**< Wrist Blood Pressure. */
+            HUMAN_INTERFACE_DEVICE_HID                     = 960,   /**< Human Interface Device (HID). */
+            KEYBOARD                                       = 961,   /**< Keyboard. */
+            MOUSE                                          = 962,   /**< Mouse. */
+            JOYSTICK                                       = 963,   /**< Joystick. */
+            GAMEPAD                                        = 964,   /**< Gamepad. */
+            DIGITIZER_TABLET                               = 965,   /**< Digitizer Tablet. */
+            CARD_READER                                    = 966,   /**< Card Reader. */
+            DIGITAL_PEN                                    = 967,   /**< Digital Pen. */
+            BARCODE_SCANNER                                = 968,   /**< Barcode Scanner. */
+            GENERIC_GLUCOSE_METER                          = 1024,  /**< Generic Glucose Meter. */
+            GENERIC_RUNNING_WALKING_SENSOR                 = 1088,  /**< Generic Running/Walking Sensor. */
+            RUNNING_WALKING_SENSOR_IN_SHOE                 = 1089,  /**< In Shoe Running/Walking Sensor. */
+            RUNNING_WALKING_SENSOR_ON_SHOE                 = 1090,  /**< On Shoe Running/Walking Sensor. */
+            RUNNING_WALKING_SENSOR_ON_HIP                  = 1091,  /**< On Hip Running/Walking Sensor. */
+            GENERIC_CYCLING                                = 1152,  /**< Generic Cycling. */
+            CYCLING_CYCLING_COMPUTER                       = 1153,  /**< Cycling Computer. */
+            CYCLING_SPEED_SENSOR                           = 1154,  /**< Cycling Speed Sensor. */
+            CYCLING_CADENCE_SENSOR                         = 1155,  /**< Cycling Cadence Sensor. */
+            CYCLING_POWER_SENSOR                           = 1156,  /**< Cycling Power Sensor. */
+            CYCLING_SPEED_AND_CADENCE_SENSOR               = 1157,  /**< Cycling Speed and Cadence Sensor. */
+            PULSE_OXIMETER_GENERIC                         = 3136,  /**< Generic Pulse Oximeter. */
+            PULSE_OXIMETER_FINGERTIP                       = 3137,  /**< Fingertip Pulse Oximeter. */
+            PULSE_OXIMETER_WRIST_WORN                      = 3138,  /**< Wrist Worn Pulse Oximeter. */
+            OUTDOOR_GENERIC                                = 5184,  /**< Generic Outdoor. */
+            OUTDOOR_LOCATION_DISPLAY_DEVICE                = 5185,  /**< Outdoor Location Display Device. */
+            OUTDOOR_LOCATION_AND_NAVIGATION_DISPLAY_DEVICE = 5186,  /**< Outdoor Location and Navigation Display Device. */
+            OUTDOOR_LOCATION_POD                           = 5187,  /**< Outdoor Location Pod. */
+            OUTDOOR_LOCATION_AND_NAVIGATION_POD            = 5188   /**< Outdoor Location and Navigation Pod. */
+        };
+    };
+    typedef AppearanceType::Type AppearanceType_t; /**< Alias for AppearanceType::Type */
 };
 
 #endif /* __BLE_PROTOCOL_H__ */

--- a/ble/BLEProtocol.h
+++ b/ble/BLEProtocol.h
@@ -104,7 +104,7 @@ namespace BLEProtocol {
             OUTDOOR_LOCATION_AND_NAVIGATION_POD            = 5188   /**< Outdoor Location and Navigation Pod. */
         };
     };
-    typedef AppearanceType::Type AppearanceType_t; /**< Alias for AppearanceType::Type */
+    typedef AppearanceType::Type AppearanceType_t; /**< Alias for @ref AppearanceType::Type */
 };
 
 #endif /* __BLE_PROTOCOL_H__ */

--- a/ble/Gap.h
+++ b/ble/Gap.h
@@ -408,7 +408,7 @@ public:
      * @param[in] appearance
      *              The new value for the device-appearance.
      */
-    virtual ble_error_t setAppearance(GapAdvertisingData::Appearance appearance) {
+    virtual ble_error_t setAppearance(BLEProtocol::AppearanceType_t appearance) {
         /* Avoid compiler warnings about unused variables. */
         (void)appearance;
 
@@ -420,7 +420,7 @@ public:
      * @param[out] appearance
      *               The new value for the device-appearance.
      */
-    virtual ble_error_t getAppearance(GapAdvertisingData::Appearance *appearanceP) {
+    virtual ble_error_t getAppearance(BLEProtocol::AppearanceType_t *appearanceP) {
         /* Avoid compiler warnings about unused variables. */
         (void)appearanceP;
 
@@ -566,7 +566,7 @@ public:
      * @param  app
      *         The appearance of the peripheral.
      */
-    ble_error_t accumulateAdvertisingPayload(GapAdvertisingData::Appearance app) {
+    ble_error_t accumulateAdvertisingPayload(BLEProtocol::AppearanceType_t app) {
         setAppearance(app);
 
         ble_error_t rc;

--- a/ble/GapAdvertisingData.h
+++ b/ble/GapAdvertisingData.h
@@ -21,6 +21,7 @@
 #include <string.h>
 
 #include "blecommon.h"
+#include "BLEProtocol.h"
 
 #define GAP_ADVERTISING_DATA_MAX_PAYLOAD        (31)
 
@@ -131,71 +132,21 @@ public:
     };
     typedef enum Flags_t Flags; /* Deprecated type alias. This may be dropped in a future release. */
 
-    /**********************************************************************/
-    /*!
-        \brief
-        A list of values for the APPEARANCE AD Type, which describes the
-        physical shape or appearance of the device.
+    /**
+     * Appearance-type for BLEProtocol addresses.
+     *
+     * @note: deprecated. Use BLEProtocol::AppearanceType_t instead.
+     */
+    typedef BLEProtocol::AppearanceType_t Appearance_t;
 
-        \par Source
-        \li \c Bluetooth Core Specification Supplement, Part A, Section 1.12
-        \li \c Bluetooth Core Specification 4.0 (Vol. 3), Part C, Section 12.2
-        \li \c https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.gap.appearance.xml
-    */
-    /**********************************************************************/
-    enum Appearance_t {
-        UNKNOWN                                        = 0,     /**< Unknown or unspecified appearance type. */
-        GENERIC_PHONE                                  = 64,    /**< Generic Phone. */
-        GENERIC_COMPUTER                               = 128,   /**< Generic Computer. */
-        GENERIC_WATCH                                  = 192,   /**< Generic Watch. */
-        WATCH_SPORTS_WATCH                             = 193,   /**< Sports Watch. */
-        GENERIC_CLOCK                                  = 256,   /**< Generic Clock. */
-        GENERIC_DISPLAY                                = 320,   /**< Generic Display. */
-        GENERIC_REMOTE_CONTROL                         = 384,   /**< Generic Remote Control. */
-        GENERIC_EYE_GLASSES                            = 448,   /**< Generic Eye Glasses. */
-        GENERIC_TAG                                    = 512,   /**< Generic Tag. */
-        GENERIC_KEYRING                                = 576,   /**< Generic Keyring. */
-        GENERIC_MEDIA_PLAYER                           = 640,   /**< Generic Media Player. */
-        GENERIC_BARCODE_SCANNER                        = 704,   /**< Generic Barcode Scanner. */
-        GENERIC_THERMOMETER                            = 768,   /**< Generic Thermometer. */
-        THERMOMETER_EAR                                = 769,   /**< Ear Thermometer. */
-        GENERIC_HEART_RATE_SENSOR                      = 832,   /**< Generic Heart Rate Sensor. */
-        HEART_RATE_SENSOR_HEART_RATE_BELT              = 833,   /**< Belt Heart Rate Sensor. */
-        GENERIC_BLOOD_PRESSURE                         = 896,   /**< Generic Blood Pressure. */
-        BLOOD_PRESSURE_ARM                             = 897,   /**< Arm Blood Pressure. */
-        BLOOD_PRESSURE_WRIST                           = 898,   /**< Wrist Blood Pressure. */
-        HUMAN_INTERFACE_DEVICE_HID                     = 960,   /**< Human Interface Device (HID). */
-        KEYBOARD                                       = 961,   /**< Keyboard. */
-        MOUSE                                          = 962,   /**< Mouse. */
-        JOYSTICK                                       = 963,   /**< Joystick. */
-        GAMEPAD                                        = 964,   /**< Gamepad. */
-        DIGITIZER_TABLET                               = 965,   /**< Digitizer Tablet. */
-        CARD_READER                                    = 966,   /**< Card Reader. */
-        DIGITAL_PEN                                    = 967,   /**< Digital Pen. */
-        BARCODE_SCANNER                                = 968,   /**< Barcode Scanner. */
-        GENERIC_GLUCOSE_METER                          = 1024,  /**< Generic Glucose Meter. */
-        GENERIC_RUNNING_WALKING_SENSOR                 = 1088,  /**< Generic Running/Walking Sensor. */
-        RUNNING_WALKING_SENSOR_IN_SHOE                 = 1089,  /**< In Shoe Running/Walking Sensor. */
-        RUNNING_WALKING_SENSOR_ON_SHOE                 = 1090,  /**< On Shoe Running/Walking Sensor. */
-        RUNNING_WALKING_SENSOR_ON_HIP                  = 1091,  /**< On Hip Running/Walking Sensor. */
-        GENERIC_CYCLING                                = 1152,  /**< Generic Cycling. */
-        CYCLING_CYCLING_COMPUTER                       = 1153,  /**< Cycling Computer. */
-        CYCLING_SPEED_SENSOR                           = 1154,  /**< Cycling Speed Sensor. */
-        CYCLING_CADENCE_SENSOR                         = 1155,  /**< Cycling Cadence Sensor. */
-        CYCLING_POWER_SENSOR                           = 1156,  /**< Cycling Power Sensor. */
-        CYCLING_SPEED_AND_CADENCE_SENSOR               = 1157,  /**< Cycling Speed and Cadence Sensor. */
-        PULSE_OXIMETER_GENERIC                         = 3136,  /**< Generic Pulse Oximeter. */
-        PULSE_OXIMETER_FINGERTIP                       = 3137,  /**< Fingertip Pulse Oximeter. */
-        PULSE_OXIMETER_WRIST_WORN                      = 3138,  /**< Wrist Worn Pulse Oximeter. */
-        OUTDOOR_GENERIC                                = 5184,  /**< Generic Outdoor. */
-        OUTDOOR_LOCATION_DISPLAY_DEVICE                = 5185,  /**< Outdoor Location Display Device. */
-        OUTDOOR_LOCATION_AND_NAVIGATION_DISPLAY_DEVICE = 5186,  /**< Outdoor Location and Navigation Display Device. */
-        OUTDOOR_LOCATION_POD                           = 5187,  /**< Outdoor Location Pod. */
-        OUTDOOR_LOCATION_AND_NAVIGATION_POD            = 5188   /**< Outdoor Location and Navigation Pod. */
-    };
-    typedef enum Appearance_t Appearance; /* Deprecated type alias. This may be dropped in a future release. */
+    /**
+     * Appearance-type for BLEProtocol addresses.
+     *
+     * @note: deprecated. Use BLEProtocol::AppearanceType_t instead.
+     */
+    typedef BLEProtocol::AppearanceType_t Appearance;
 
-    GapAdvertisingData(void) : _payload(), _payloadLen(0), _appearance(GENERIC_TAG) {
+    GapAdvertisingData(void) : _payload(), _payloadLen(0), _appearance(BLEProtocol::AppearanceType::GENERIC_TAG) {
         /* empty */
     }
 
@@ -355,7 +306,7 @@ public:
      * @return BLE_ERROR_BUFFER_OVERFLOW if the specified data would cause the
      * advertising buffer to overflow, else BLE_ERROR_NONE.
      */
-    ble_error_t addAppearance(Appearance appearance = GENERIC_TAG) {
+    ble_error_t addAppearance(BLEProtocol::AppearanceType_t appearance = BLEProtocol::AppearanceType::GENERIC_TAG) {
         _appearance = appearance;
         return addData(GapAdvertisingData::APPEARANCE, (uint8_t *)&appearance, 2);
     }

--- a/ble/GapAdvertisingData.h
+++ b/ble/GapAdvertisingData.h
@@ -134,6 +134,66 @@ public:
 
     /**
      * Appearance-type for BLEProtocol addresses.
+     * @note: deprecated. Use @ref BLEProtocol::AppearanceType_t instead.
+     *
+     * DEPRECATION ALERT: The following constants have been left in their
+     * deprecated state to transparenly support existing applications which may
+     * have used GapAdvertisingData::*.
+     */
+    enum {
+        UNKNOWN                                        = BLEProtocol::AppearanceType::UNKNOWN,                                         /**< Unknown or unspecified appearance type. */
+        GENERIC_PHONE                                  = BLEProtocol::AppearanceType::GENERIC_PHONE,                                   /**< Generic Phone. */
+        GENERIC_COMPUTER                               = BLEProtocol::AppearanceType::GENERIC_COMPUTER,                                /**< Generic Computer. */
+        GENERIC_WATCH                                  = BLEProtocol::AppearanceType::GENERIC_WATCH,                                   /**< Generic Watch. */
+        WATCH_SPORTS_WATCH                             = BLEProtocol::AppearanceType::WATCH_SPORTS_WATCH,                              /**< Sports Watch. */
+        GENERIC_CLOCK                                  = BLEProtocol::AppearanceType::GENERIC_CLOCK,                                   /**< Generic Clock. */
+        GENERIC_DISPLAY                                = BLEProtocol::AppearanceType::GENERIC_DISPLAY,                                 /**< Generic Display. */
+        GENERIC_REMOTE_CONTROL                         = BLEProtocol::AppearanceType::GENERIC_REMOTE_CONTROL,                          /**< Generic Remote Control. */
+        GENERIC_EYE_GLASSES                            = BLEProtocol::AppearanceType::GENERIC_EYE_GLASSES,                             /**< Generic Eye Glasses. */
+        GENERIC_TAG                                    = BLEProtocol::AppearanceType::GENERIC_TAG,                                     /**< Generic Tag. */
+        GENERIC_KEYRING                                = BLEProtocol::AppearanceType::GENERIC_KEYRING,                                 /**< Generic Keyring. */
+        GENERIC_MEDIA_PLAYER                           = BLEProtocol::AppearanceType::GENERIC_MEDIA_PLAYER,                            /**< Generic Media Player. */
+        GENERIC_BARCODE_SCANNER                        = BLEProtocol::AppearanceType::GENERIC_BARCODE_SCANNER,                         /**< Generic Barcode Scanner. */
+        GENERIC_THERMOMETER                            = BLEProtocol::AppearanceType::GENERIC_THERMOMETER,                             /**< Generic Thermometer. */
+        THERMOMETER_EAR                                = BLEProtocol::AppearanceType::THERMOMETER_EAR,                                 /**< Ear Thermometer. */
+        GENERIC_HEART_RATE_SENSOR                      = BLEProtocol::AppearanceType::GENERIC_HEART_RATE_SENSOR,                       /**< Generic Heart Rate Sensor. */
+        HEART_RATE_SENSOR_HEART_RATE_BELT              = BLEProtocol::AppearanceType::HEART_RATE_SENSOR_HEART_RATE_BELT,               /**< Belt Heart Rate Sensor. */
+        GENERIC_BLOOD_PRESSURE                         = BLEProtocol::AppearanceType::GENERIC_BLOOD_PRESSURE,                          /**< Generic Blood Pressure. */
+        BLOOD_PRESSURE_ARM                             = BLEProtocol::AppearanceType::BLOOD_PRESSURE_ARM,                              /**< Arm Blood Pressure. */
+        BLOOD_PRESSURE_WRIST                           = BLEProtocol::AppearanceType::BLOOD_PRESSURE_WRIST,                            /**< Wrist Blood Pressure. */
+        HUMAN_INTERFACE_DEVICE_HID                     = BLEProtocol::AppearanceType::HUMAN_INTERFACE_DEVICE_HID,                      /**< Human Interface Device (HID). */
+        KEYBOARD                                       = BLEProtocol::AppearanceType::KEYBOARD,                                        /**< Keyboard. */
+        MOUSE                                          = BLEProtocol::AppearanceType::MOUSE,                                           /**< Mouse. */
+        JOYSTICK                                       = BLEProtocol::AppearanceType::JOYSTICK,                                        /**< Joystick. */
+        GAMEPAD                                        = BLEProtocol::AppearanceType::GAMEPAD,                                         /**< Gamepad. */
+        DIGITIZER_TABLET                               = BLEProtocol::AppearanceType::DIGITIZER_TABLET,                                /**< Digitizer Tablet. */
+        CARD_READER                                    = BLEProtocol::AppearanceType::CARD_READER,                                     /**< Card Reader. */
+        DIGITAL_PEN                                    = BLEProtocol::AppearanceType::DIGITAL_PEN,                                     /**< Digital Pen. */
+        BARCODE_SCANNER                                = BLEProtocol::AppearanceType::BARCODE_SCANNER,                                 /**< Barcode Scanner. */
+        GENERIC_GLUCOSE_METER                          = BLEProtocol::AppearanceType::GENERIC_GLUCOSE_METER,                           /**< Generic Glucose Meter. */
+        GENERIC_RUNNING_WALKING_SENSOR                 = BLEProtocol::AppearanceType::GENERIC_RUNNING_WALKING_SENSOR,                  /**< Generic Running/Walking Sensor. */
+        RUNNING_WALKING_SENSOR_IN_SHOE                 = BLEProtocol::AppearanceType::RUNNING_WALKING_SENSOR_IN_SHOE,                  /**< In Shoe Running/Walking Sensor. */
+        RUNNING_WALKING_SENSOR_ON_SHOE                 = BLEProtocol::AppearanceType::RUNNING_WALKING_SENSOR_ON_SHOE,                  /**< On Shoe Running/Walking Sensor. */
+        RUNNING_WALKING_SENSOR_ON_HIP                  = BLEProtocol::AppearanceType::RUNNING_WALKING_SENSOR_ON_HIP,                   /**< On Hip Running/Walking Sensor. */
+        GENERIC_CYCLING                                = BLEProtocol::AppearanceType::GENERIC_CYCLING,                                 /**< Generic Cycling. */
+        CYCLING_CYCLING_COMPUTER                       = BLEProtocol::AppearanceType::CYCLING_CYCLING_COMPUTER,                        /**< Cycling Computer. */
+        CYCLING_SPEED_SENSOR                           = BLEProtocol::AppearanceType::CYCLING_SPEED_SENSOR,                            /**< Cycling Speed Sensor. */
+        CYCLING_CADENCE_SENSOR                         = BLEProtocol::AppearanceType::CYCLING_CADENCE_SENSOR,                          /**< Cycling Cadence Sensor. */
+        CYCLING_POWER_SENSOR                           = BLEProtocol::AppearanceType::CYCLING_POWER_SENSOR,                            /**< Cycling Power Sensor. */
+        CYCLING_SPEED_AND_CADENCE_SENSOR               = BLEProtocol::AppearanceType::CYCLING_SPEED_AND_CADENCE_SENSOR,                /**< Cycling Speed and Cadence Sensor. */
+        PULSE_OXIMETER_GENERIC                         = BLEProtocol::AppearanceType::PULSE_OXIMETER_GENERIC,                          /**< Generic Pulse Oximeter. */
+        PULSE_OXIMETER_FINGERTIP                       = BLEProtocol::AppearanceType::PULSE_OXIMETER_FINGERTIP,                        /**< Fingertip Pulse Oximeter. */
+        PULSE_OXIMETER_WRIST_WORN                      = BLEProtocol::AppearanceType::PULSE_OXIMETER_WRIST_WORN,                       /**< Wrist Worn Pulse Oximeter. */
+        GENERIC_WEIGHT_SCALE                           = BLEProtocol::AppearanceType::GENERIC_WEIGHT_SCALE,                            /**< Generic Weight Scale */
+        OUTDOOR_GENERIC                                = BLEProtocol::AppearanceType::OUTDOOR_GENERIC,                                 /**< Generic Outdoor. */
+        OUTDOOR_LOCATION_DISPLAY_DEVICE                = BLEProtocol::AppearanceType::OUTDOOR_LOCATION_DISPLAY_DEVICE,                 /**< Outdoor Location Display Device. */
+        OUTDOOR_LOCATION_AND_NAVIGATION_DISPLAY_DEVICE = BLEProtocol::AppearanceType::OUTDOOR_LOCATION_AND_NAVIGATION_DISPLAY_DEVICE,  /**< Outdoor Location and Navigation Display Device. */
+        OUTDOOR_LOCATION_POD                           = BLEProtocol::AppearanceType::OUTDOOR_LOCATION_POD,                            /**< Outdoor Location Pod. */
+        OUTDOOR_LOCATION_AND_NAVIGATION_POD            = BLEProtocol::AppearanceType::OUTDOOR_LOCATION_AND_NAVIGATION_POD              /**< Outdoor Location and Navigation Pod. */
+    };
+
+    /**
+     * Appearance-type for BLEProtocol addresses.
      *
      * @note: deprecated. Use @ref BLEProtocol::AppearanceType_t instead.
      */

--- a/ble/GapAdvertisingData.h
+++ b/ble/GapAdvertisingData.h
@@ -135,14 +135,14 @@ public:
     /**
      * Appearance-type for BLEProtocol addresses.
      *
-     * @note: deprecated. Use BLEProtocol::AppearanceType_t instead.
+     * @note: deprecated. Use @ref BLEProtocol::AppearanceType_t instead.
      */
     typedef BLEProtocol::AppearanceType_t Appearance_t;
 
     /**
      * Appearance-type for BLEProtocol addresses.
      *
-     * @note: deprecated. Use BLEProtocol::AppearanceType_t instead.
+     * @note: deprecated. Use @ref BLEProtocol::AppearanceType_t instead.
      */
     typedef BLEProtocol::AppearanceType_t Appearance;
 

--- a/ble/blecommon.h
+++ b/ble/blecommon.h
@@ -49,62 +49,6 @@ enum {
     BLE_UUID_GAP_CHARACTERISTIC_PPCP             = 0x2A04, /**< Peripheral Preferred Connection Parameters Characteristic. */
 };
 
-/*! Bluetooth appearance values.
- *  @note Retrieved from http://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.gap.appearance.xml
- */
-enum {
-    BLE_APPEARANCE_UNKNOWN                             =    0, /**< Unknown. */
-    BLE_APPEARANCE_GENERIC_PHONE                       =   64, /**< Generic Phone. */
-    BLE_APPEARANCE_GENERIC_COMPUTER                    =  128, /**< Generic Computer. */
-    BLE_APPEARANCE_GENERIC_WATCH                       =  192, /**< Generic Watch. */
-    BLE_APPEARANCE_WATCH_SPORTS_WATCH                  =  193, /**< Watch: Sports Watch. */
-    BLE_APPEARANCE_GENERIC_CLOCK                       =  256, /**< Generic Clock. */
-    BLE_APPEARANCE_GENERIC_DISPLAY                     =  320, /**< Generic Display. */
-    BLE_APPEARANCE_GENERIC_REMOTE_CONTROL              =  384, /**< Generic Remote Control. */
-    BLE_APPEARANCE_GENERIC_EYE_GLASSES                 =  448, /**< Generic Eye-glasses. */
-    BLE_APPEARANCE_GENERIC_TAG                         =  512, /**< Generic Tag. */
-    BLE_APPEARANCE_GENERIC_KEYRING                     =  576, /**< Generic Keyring. */
-    BLE_APPEARANCE_GENERIC_MEDIA_PLAYER                =  640, /**< Generic Media Player. */
-    BLE_APPEARANCE_GENERIC_BARCODE_SCANNER             =  704, /**< Generic Barcode Scanner. */
-    BLE_APPEARANCE_GENERIC_THERMOMETER                 =  768, /**< Generic Thermometer. */
-    BLE_APPEARANCE_THERMOMETER_EAR                     =  769, /**< Thermometer: Ear. */
-    BLE_APPEARANCE_GENERIC_HEART_RATE_SENSOR           =  832, /**< Generic Heart Rate Sensor. */
-    BLE_APPEARANCE_HEART_RATE_SENSOR_HEART_RATE_BELT   =  833, /**< Heart Rate Sensor: Heart Rate Belt. */
-    BLE_APPEARANCE_GENERIC_BLOOD_PRESSURE              =  896, /**< Generic Blood Pressure. */
-    BLE_APPEARANCE_BLOOD_PRESSURE_ARM                  =  897, /**< Blood Pressure: Arm. */
-    BLE_APPEARANCE_BLOOD_PRESSURE_WRIST                =  898, /**< Blood Pressure: Wrist. */
-    BLE_APPEARANCE_GENERIC_HID                         =  960, /**< Human Interface Device (HID). */
-    BLE_APPEARANCE_HID_KEYBOARD                        =  961, /**< Keyboard (HID subtype). */
-    BLE_APPEARANCE_HID_MOUSE                           =  962, /**< Mouse (HID subtype). */
-    BLE_APPEARANCE_HID_JOYSTICK                        =  963, /**< Joystick (HID subtype). */
-    BLE_APPEARANCE_HID_GAMEPAD                         =  964, /**< Gamepad (HID subtype). */
-    BLE_APPEARANCE_HID_DIGITIZERSUBTYPE                =  965, /**< Digitizer Tablet (HID subtype). */
-    BLE_APPEARANCE_HID_CARD_READER                     =  966, /**< Card Reader (HID subtype). */
-    BLE_APPEARANCE_HID_DIGITAL_PEN                     =  967, /**< Digital Pen (HID subtype). */
-    BLE_APPEARANCE_HID_BARCODE                         =  968, /**< Barcode Scanner (HID subtype). */
-    BLE_APPEARANCE_GENERIC_GLUCOSE_METER               = 1024, /**< Generic Glucose Meter. */
-    BLE_APPEARANCE_GENERIC_RUNNING_WALKING_SENSOR      = 1088, /**< Generic Running Walking Sensor. */
-    BLE_APPEARANCE_RUNNING_WALKING_SENSOR_IN_SHOE      = 1089, /**< Running Walking Sensor: In-Shoe. */
-    BLE_APPEARANCE_RUNNING_WALKING_SENSOR_ON_SHOE      = 1090, /**< Running Walking Sensor: On-Shoe. */
-    BLE_APPEARANCE_RUNNING_WALKING_SENSOR_ON_HIP       = 1091, /**< Running Walking Sensor: On-Hip. */
-    BLE_APPEARANCE_GENERIC_CYCLING                     = 1152, /**< Generic Cycling. */
-    BLE_APPEARANCE_CYCLING_CYCLING_COMPUTER            = 1153, /**< Cycling: Cycling Computer. */
-    BLE_APPEARANCE_CYCLING_SPEED_SENSOR                = 1154, /**< Cycling: Speed Sensor. */
-    BLE_APPEARANCE_CYCLING_CADENCE_SENSOR              = 1155, /**< Cycling: Cadence Sensor. */
-    BLE_APPEARANCE_CYCLING_POWER_SENSOR                = 1156, /**< Cycling: Power Sensor. */
-    BLE_APPEARANCE_CYCLING_SPEED_CADENCE_SENSOR        = 1157, /**< Cycling: Speed and Cadence Sensor. */
-    BLE_APPEARANCE_GENERIC_PULSE_OXIMETER              = 3136, /**< Generic Pulse Oximeter. */
-    BLE_APPEARANCE_PULSE_OXIMETER_FINGERTIP            = 3137, /**< Fingertip (Pulse Oximeter subtype). */
-    BLE_APPEARANCE_PULSE_OXIMETER_WRIST_WORN           = 3138, /**< Wrist Worn (Pulse Oximeter subtype). */
-    BLE_APPEARANCE_GENERIC_WEIGHT_SCALE                = 3200, /**< Generic Weight Scale. */
-    BLE_APPEARANCE_GENERIC_OUTDOOR_SPORTS_ACT          = 5184, /**< Generic Outdoor Sports Activity. */
-    BLE_APPEARANCE_OUTDOOR_SPORTS_ACT_LOC_DISP         = 5185, /**< Location Display Device (Outdoor Sports Activity subtype). */
-    BLE_APPEARANCE_OUTDOOR_SPORTS_ACT_LOC_AND_NAV_DISP = 5186, /**< Location and Navigation Display Device (Outdoor Sports Activity subtype). */
-    BLE_APPEARANCE_OUTDOOR_SPORTS_ACT_LOC_POD          = 5187, /**< Location Pod (Outdoor Sports Activity subtype). */
-    BLE_APPEARANCE_OUTDOOR_SPORTS_ACT_LOC_AND_NAV_POD  = 5188, /**< Location and Navigation Pod (Outdoor Sports Activity subtype). */
-};
-
-
 /*! @brief Error codes for the BLE API. */
 enum ble_error_t {
     BLE_ERROR_NONE                      = 0, /**< No error. */

--- a/ble/services/URIBeaconConfigService.h
+++ b/ble/services/URIBeaconConfigService.h
@@ -174,7 +174,7 @@ class URIBeaconConfigService {
             reversedServiceUUID[i] = UUID_URI_BEACON_SERVICE[sizeof(UUID_URI_BEACON_SERVICE) - i - 1];
         }
         ble.gap().accumulateAdvertisingPayload(GapAdvertisingData::COMPLETE_LIST_128BIT_SERVICE_IDS, reversedServiceUUID, sizeof(reversedServiceUUID));
-        ble.gap().accumulateAdvertisingPayload(GapAdvertisingData::GENERIC_TAG);
+        ble.gap().accumulateAdvertisingPayload(BLEProtocol::AppearanceType::GENERIC_TAG);
         ble.gap().accumulateScanResponse(GapAdvertisingData::COMPLETE_LOCAL_NAME, reinterpret_cast<const uint8_t *>(&DEVICE_NAME), sizeof(DEVICE_NAME));
         ble.gap().accumulateScanResponse(GapAdvertisingData::TX_POWER_LEVEL,
                                          reinterpret_cast<uint8_t *>(&defaultAdvPowerLevels[URIBeaconConfigService::TX_POWER_MODE_LOW]),


### PR DESCRIPTION
There were two different enums (in GapAdvertisingData.h and blecommon.h) that
defined the appearance values for the BLE Appearance characteristic. This code
is removed and a single copy of the enum is included in BLEProcotol.h to
continue the effort of putting general information defined by the BLE spec in
a single file.
@rgrover @LiyouZhou @pan- 