### PR TITLE
add experimental support for whitelisting

### DIFF
--- a/ble/BLE.h
+++ b/ble/BLE.h
@@ -239,7 +239,7 @@ public:
      * ble.setAddress(...) should be replaced with
      * ble.gap().setAddress(...).
      */
-    ble_error_t setAddress(BLEProtocol::AddressType_t type, const BLEProtocol::Address_t address) {
+    ble_error_t setAddress(BLEProtocol::AddressType_t type, const BLEProtocol::AddressBytes_t address) {
         return gap().setAddress(type, address);
     }
 
@@ -252,7 +252,7 @@ public:
      * ble.getAddress(...) should be replaced with
      * ble.gap().getAddress(...).
      */
-    ble_error_t getAddress(BLEProtocol::AddressType_t *typeP, BLEProtocol::Address_t address) {
+    ble_error_t getAddress(BLEProtocol::AddressType_t *typeP, BLEProtocol::AddressBytes_t address) {
         return gap().getAddress(typeP, address);
     }
 
@@ -752,10 +752,10 @@ public:
      * ble.connect(...) should be replaced with
      * ble.gap().connect(...).
      */
-    ble_error_t connect(const BLEProtocol::Address_t   peerAddr,
-                        BLEProtocol::AddressType_t     peerAddrType = BLEProtocol::AddressType::RANDOM_STATIC,
-                        const Gap::ConnectionParams_t *connectionParams = NULL,
-                        const GapScanningParams       *scanParams = NULL) {
+    ble_error_t connect(const BLEProtocol::AddressBytes_t  peerAddr,
+                        BLEProtocol::AddressType_t         peerAddrType     = BLEProtocol::AddressType::RANDOM_STATIC,
+                        const Gap::ConnectionParams_t     *connectionParams = NULL,
+                        const GapScanningParams           *scanParams       = NULL) {
         return gap().connect(peerAddr, peerAddrType, connectionParams, scanParams);
     }
 

--- a/ble/BLEProtocol.h
+++ b/ble/BLEProtocol.h
@@ -86,16 +86,18 @@ namespace BLEProtocol {
      * packets (in the case of an advertiser) received from devices whose
      * Bluetooth Address is not present in the white list will simply be
      * dropped.
+     *
+     * @note A whitelist has a fixed size.
      */
     struct Whitelist_t {
         AddressBytes_t *addrs[];  /**< Pointer to an array of device address pointers, pointing to addresses to be used in whitelist.
                                        NULL if none are given. */
         uint8_t        addrCount; /**< Count of device addresses in the array `addrs`.
-                                       @note there will be some upper limit to this count imposed by the underlying BLE stack. */
+                                       @note There will be some upper limit to this size imposed by the underlying BLE stack. */
         Irk_t         *irks;      /**< Pointer to an array of Identity Resolving Key (IRK) pointers, each pointing
                                        to an IRK in the whitelist. NULL if none are given. */
         uint8_t        irkCount;  /**< Count of IRKs in array.
-                                       @note there will be some upper limit to this count imposed by the underlying BLE stack. */
+                                       @note There will be some upper limit to this size imposed by the underlying BLE stack. */
     };
 };
 

--- a/ble/BLEProtocol.h
+++ b/ble/BLEProtocol.h
@@ -98,14 +98,14 @@ namespace BLEProtocol {
      *     changed and advertising re-enabled.
      */
     struct Whitelist_t {
-        Address_t *addrs[];   /**< Pointer to an array of device address pointers, pointing to addresses to be
-                                   used in whitelist. NULL if none are given. */
-        uint8_t    addrCount; /**< Count of device addresses in the array `addrs`.
-                                   @note There will be some upper limit to this size imposed by the underlying BLE stack. */
-        Irk_t     *irks;      /**< Pointer to an array of Identity Resolving Key (IRK) pointers, each pointing
-                                   to an IRK in the whitelist. NULL if none are given. */
-        uint8_t    irkCount;  /**< Count of IRKs in array.
-                                   @note There will be some upper limit to this size imposed by the underlying BLE stack. */
+        const Address_t **addrs;     /**< Pointer to an array of device address pointers, pointing to addresses to be
+                                          used in whitelist. NULL if none are given. */
+        uint8_t           addrCount; /**< Count of device addresses in the array `addrs`.
+                                          @note There will be some upper limit to this size imposed by the underlying BLE stack. */
+        const Irk_t     **irks;      /**< Pointer to an array of Identity Resolving Key (IRK) pointers, each pointing
+                                          to an IRK in the whitelist. NULL if none are given. */
+        uint8_t           irkCount;  /**< Count of IRKs in array.
+                                          @note There will be some upper limit to this size imposed by the underlying BLE stack. */
     };
 };
 

--- a/ble/BLEProtocol.h
+++ b/ble/BLEProtocol.h
@@ -96,6 +96,20 @@ namespace BLEProtocol {
      *     to scan requests or connection requests, the whitelist cannot be
      *     changed until advertising is disabled. The whitelist can then be
      *     changed and advertising re-enabled.
+     *
+     * Here's how you might use a whitelist at a peripheral to populate a STATIC address:
+     *
+     *     const BLEProtocol::AddressBytes_t addrBytes = {0xc9, 0xd0, 0x04, 0x6c, 0xe5, 0x73}; // PLEASE REPALCE THIS
+     *     const BLEProtocol::Address_t peerAddr(BLEProtocol::AddressType::RANDOM_STATIC, addrBytes);
+     *     const BLEProtocol::Address_t *table[] = {&peerAddr};
+     *
+     *     BLEProtocol::Whitelist_t whitelist;
+     *     whitelist.addrs     = table;
+     *     whitelist.addrCount = sizeof(table) / sizeof(const BLEProtocol::Address_t *);
+     *     whitelist.irks      = NULL;
+     *     whitelist.irkCount  = 0;
+     *
+     *     ble.gap().getAdvertisingParams().setWhitelist(&whitelist);
      */
     struct Whitelist_t {
         const Address_t **addrs;     /**< Pointer to an array of device address pointers, pointing to addresses to be

--- a/ble/BLEProtocol.h
+++ b/ble/BLEProtocol.h
@@ -25,15 +25,21 @@
  * A common namespace for types and constants used everywhere in BLE API.
  */
 namespace BLEProtocol {
-    /**< Address-type for Protocol addresses. */
-    struct AddressType { /* Adding a struct to encapsulate the contained enumeration
-                          * prevents polluting the BLEProtocol namespace with the
-                          * enumerated values. It also allows type-aliases for the
-                          * enumeration while retaining the enumerated values. i.e.
-                          *
-                          * doing:
-                          *       typedef AddressType_t AliasedType_t;
-                          * would allow the use of AliasedType_t::PUBLIC in code. */
+    /**<
+     * A simple container for the enumeration of address-types for Protocol addresses.
+     *
+     * Adding a struct to encapsulate the contained enumeration prevents
+     * polluting the BLEProtocol namespace with the enumerated values. It also
+     * allows type-aliases for the enumeration while retaining the enumerated
+     * values. i.e.
+     *
+     * doing:
+     *       typedef AddressType AliasedType;
+     *
+     * would allow the use of AliasedType::PUBLIC in code.
+     */
+    struct AddressType {
+        /**< Address-types for Protocol addresses. */
         enum Type {
             PUBLIC = 0,
             RANDOM_STATIC,

--- a/ble/BLEProtocol.h
+++ b/ble/BLEProtocol.h
@@ -98,14 +98,14 @@ namespace BLEProtocol {
      *     changed and advertising re-enabled.
      */
     struct Whitelist_t {
-        AddressBytes_t *addrs[];  /**< Pointer to an array of device address pointers, pointing to addresses to be used in whitelist.
-                                       NULL if none are given. */
-        uint8_t        addrCount; /**< Count of device addresses in the array `addrs`.
-                                       @note There will be some upper limit to this size imposed by the underlying BLE stack. */
-        Irk_t         *irks;      /**< Pointer to an array of Identity Resolving Key (IRK) pointers, each pointing
-                                       to an IRK in the whitelist. NULL if none are given. */
-        uint8_t        irkCount;  /**< Count of IRKs in array.
-                                       @note There will be some upper limit to this size imposed by the underlying BLE stack. */
+        Address_t *addrs[];   /**< Pointer to an array of device address pointers, pointing to addresses to be
+                                   used in whitelist. NULL if none are given. */
+        uint8_t    addrCount; /**< Count of device addresses in the array `addrs`.
+                                   @note There will be some upper limit to this size imposed by the underlying BLE stack. */
+        Irk_t     *irks;      /**< Pointer to an array of Identity Resolving Key (IRK) pointers, each pointing
+                                   to an IRK in the whitelist. NULL if none are given. */
+        uint8_t    irkCount;  /**< Count of IRKs in array.
+                                   @note There will be some upper limit to this size imposed by the underlying BLE stack. */
     };
 };
 

--- a/ble/BLEProtocol.h
+++ b/ble/BLEProtocol.h
@@ -59,7 +59,7 @@ namespace BLEProtocol {
         AddressType_t  type;    /**< @ref AddressType_t */
         AddressBytes_t address; /**< @ref AddressBytes_t */
 
-        Address_t(AddressType_t typeIn, const AddressBytes_t addressIn) : type(typeIn) {
+        Address_t(AddressType_t typeIn, const AddressBytes_t& addressIn) : type(typeIn) {
             std::copy(addressIn, addressIn + ADDR_LEN, address);
         }
     };
@@ -99,7 +99,7 @@ namespace BLEProtocol {
      *
      * Here's how you might use a whitelist at a peripheral to populate a STATIC address:
      *
-     *     const BLEProtocol::AddressBytes_t addrBytes = {0xc9, 0xd0, 0x04, 0x6c, 0xe5, 0x73}; // PLEASE REPALCE THIS
+     *     const BLEProtocol::AddressBytes_t addrBytes = {0xc9, 0xd0, 0x04, 0x6c, 0xe5, 0x73}; // PLEASE REPLACE THIS
      *     const BLEProtocol::Address_t peerAddr(BLEProtocol::AddressType::RANDOM_STATIC, addrBytes);
      *     const BLEProtocol::Address_t *table[] = {&peerAddr};
      *

--- a/ble/BLEProtocol.h
+++ b/ble/BLEProtocol.h
@@ -110,6 +110,8 @@ namespace BLEProtocol {
      *     whitelist.irkCount  = 0;
      *
      *     ble.gap().getAdvertisingParams().setWhitelist(&whitelist);
+     *
+     * @note support for whitelisting is still experimental.
      */
     struct Whitelist_t {
         const Address_t **addrs;     /**< Pointer to an array of device address pointers, pointing to addresses to be

--- a/ble/BLEProtocol.h
+++ b/ble/BLEProtocol.h
@@ -68,17 +68,24 @@ namespace BLEProtocol {
     typedef uint8_t Irk_t[SECURITY_KEY_LEN];   /**@brief Identity Resolving Key. */
 
     /**
-     * Whitelisting is an important feature available in BLE. White-lists allow hosts to filter devices
-     * when advertising, scanning, and establishing connections on both sides. White lists are
-     * simply arrays of Bluetooth device addresses that are populated by the host and stored
-     * and used in the controller.
+     * Whitelisting is an important feature available in BLE. White-lists allow
+     * hosts to filter devices when advertising, scanning, and establishing
+     * connections on both sides. White lists are simply arrays of Bluetooth
+     * device addresses that are populated by the host (i.e. the processor where
+     * the application is running) and stored and used in the controller (i.e.
+     * Bluetooth controller).
      *
-     * A device scanning or initiating a connection can use a white list to limit the number of
-     * devices that will be detected or with which it can connect, and the advertising device
-     * can use a white list to specify which peers it will accept an incoming connection from.
+     * A device scanning or initiating a connection can use a white list to
+     * limit the number of devices that will be detected or with which it can
+     * connect, and the advertising device can use a white list to specify which
+     * peers it will accept an incoming connection from. This is especially
+     * useful when searching for a few known devices in a fog of advertising
+     * packets in busy locations.
      *
-     * Any advertising packets (in the case of a scanner) or connection request packets (in the case of an advertiser)
-     * received from devices whose Bluetooth Address is not present in the white list will simply be dropped.
+     * Any advertising packets (in the case of a scanner) or connection request
+     * packets (in the case of an advertiser) received from devices whose
+     * Bluetooth Address is not present in the white list will simply be
+     * dropped.
      */
     struct Whitelist_t {
         AddressBytes_t *addrs[];  /**< Pointer to an array of device address pointers, pointing to addresses to be used in whitelist.

--- a/ble/BLEProtocol.h
+++ b/ble/BLEProtocol.h
@@ -19,6 +19,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <algorithm>
 
 /**
  * A common namespace for types and constants used everywhere in BLE API.
@@ -44,6 +45,18 @@ namespace BLEProtocol {
 
     static const size_t ADDR_LEN = 6;         /**< Length (in octets) of the BLE MAC address. */
     typedef uint8_t AddressBytes_t[ADDR_LEN]; /**< 48-bit address bytes, in LSB format. */
+
+    /**
+     * BLE address. It contains an address-type (@ref AddressType_t) and bytes (@ref AddressBytes_t).
+     */
+    struct Address_t {
+        AddressType_t  type;
+        AddressBytes_t address;
+
+        Address_t(AddressType_t typeIn, const AddressBytes_t addressIn) : type(typeIn) {
+            std::copy(addressIn, addressIn + ADDR_LEN, address);
+        }
+    };
 };
 
 #endif /* __BLE_PROTOCOL_H__ */

--- a/ble/BLEProtocol.h
+++ b/ble/BLEProtocol.h
@@ -57,6 +57,33 @@ namespace BLEProtocol {
             std::copy(addressIn, addressIn + ADDR_LEN, address);
         }
     };
+
+    static const size_t SECURITY_KEY_LEN = 16; /**@brief GAP Security Key Length. */
+    typedef uint8_t Irk_t[SECURITY_KEY_LEN]; /**@brief Identity Resolving Key. */
+
+    /**
+     * Whitelisting is an important feature available in BLE. White-lists allow hosts to filter devices
+     * when advertising, scanning, and establishing connections on both sides. White lists are
+     * simply arrays of Bluetooth device addresses that are populated by the host and stored
+     * and used in the controller.
+     *
+     * A device scanning or initiating a connection can use a white list to limit the number of
+     * devices that will be detected or with which it can connect, and the advertising device
+     * can use a white list to specify which peers it will accept an incoming connection from.
+     *
+     * Any advertising packets (in the case of a scanner) or connection request packets (in the case of an advertiser)
+     * received from devices whose Bluetooth Address is not present in the white list will simply be dropped.
+     */
+    struct Whitelist_t {
+        AddressBytes_t *addrs[];   /**< Pointer to an array of device address pointers, pointing to addresses to be used in whitelist.
+                                       NULL if none are given. */
+        uint8_t        addrCount; /**< Count of device addresses in the array `addrs`.
+                                       @note there will be some upper limit to this count imposed by the underlying BLE stack. */
+        Irk_t         *irks;      /**< Pointer to an array of Identity Resolving Key (IRK) pointers, each pointing
+                                       to an IRK in the whitelist. NULL if none are given. */
+        uint8_t        irkCount;  /**< Count of IRKs in array.
+                                       @note there will be some upper limit to this count imposed by the underlying BLE stack. */
+    };
 };
 
 #endif /* __BLE_PROTOCOL_H__ */

--- a/ble/BLEProtocol.h
+++ b/ble/BLEProtocol.h
@@ -47,7 +47,7 @@ namespace BLEProtocol {
             RANDOM_PRIVATE_NON_RESOLVABLE
         };
     };
-    typedef AddressType::Type AddressType_t; /**< Alias for AddressType::Type */
+    typedef AddressType::Type AddressType_t;   /**< Alias for AddressType::Type */
 
     static const size_t ADDR_LEN = 6;         /**< Length (in octets) of the BLE MAC address. */
     typedef uint8_t AddressBytes_t[ADDR_LEN]; /**< 48-bit address bytes, in LSB format. */
@@ -65,7 +65,7 @@ namespace BLEProtocol {
     };
 
     static const size_t SECURITY_KEY_LEN = 16; /**@brief GAP Security Key Length. */
-    typedef uint8_t Irk_t[SECURITY_KEY_LEN]; /**@brief Identity Resolving Key. */
+    typedef uint8_t Irk_t[SECURITY_KEY_LEN];   /**@brief Identity Resolving Key. */
 
     /**
      * Whitelisting is an important feature available in BLE. White-lists allow hosts to filter devices
@@ -81,7 +81,7 @@ namespace BLEProtocol {
      * received from devices whose Bluetooth Address is not present in the white list will simply be dropped.
      */
     struct Whitelist_t {
-        AddressBytes_t *addrs[];   /**< Pointer to an array of device address pointers, pointing to addresses to be used in whitelist.
+        AddressBytes_t *addrs[];  /**< Pointer to an array of device address pointers, pointing to addresses to be used in whitelist.
                                        NULL if none are given. */
         uint8_t        addrCount; /**< Count of device addresses in the array `addrs`.
                                        @note there will be some upper limit to this count imposed by the underlying BLE stack. */

--- a/ble/BLEProtocol.h
+++ b/ble/BLEProtocol.h
@@ -42,8 +42,8 @@ namespace BLEProtocol {
     };
     typedef AddressType::Type AddressType_t; /**< Alias for AddressType::Type */
 
-    static const size_t ADDR_LEN = 6;        /**< Length (in octets) of the BLE MAC address. */
-    typedef uint8_t Address_t[ADDR_LEN];     /**< 48-bit address, in LSB format. */
+    static const size_t ADDR_LEN = 6;         /**< Length (in octets) of the BLE MAC address. */
+    typedef uint8_t AddressBytes_t[ADDR_LEN]; /**< 48-bit address bytes, in LSB format. */
 };
 
 #endif /* __BLE_PROTOCOL_H__ */

--- a/ble/BLEProtocol.h
+++ b/ble/BLEProtocol.h
@@ -50,8 +50,8 @@ namespace BLEProtocol {
      * BLE address. It contains an address-type (@ref AddressType_t) and bytes (@ref AddressBytes_t).
      */
     struct Address_t {
-        AddressType_t  type;
-        AddressBytes_t address;
+        AddressType_t  type;    /**< @ref AddressType_t */
+        AddressBytes_t address; /**< @ref AddressBytes_t */
 
         Address_t(AddressType_t typeIn, const AddressBytes_t addressIn) : type(typeIn) {
             std::copy(addressIn, addressIn + ADDR_LEN, address);

--- a/ble/BLEProtocol.h
+++ b/ble/BLEProtocol.h
@@ -87,7 +87,15 @@ namespace BLEProtocol {
      * Bluetooth Address is not present in the white list will simply be
      * dropped.
      *
-     * @note A whitelist has a fixed size.
+     * @note A whitelist has a fixed size. There will be some upper limit
+     *     imposed by the underlying BLE stack.
+     *
+     * @note It is not possible to change the contents of the whitelist while it
+     *     is being used. For example, if the device is advertising and using
+     *     the whitelist to filter the devices to and from which it will respond
+     *     to scan requests or connection requests, the whitelist cannot be
+     *     changed until advertising is disabled. The whitelist can then be
+     *     changed and advertising re-enabled.
      */
     struct Whitelist_t {
         AddressBytes_t *addrs[];  /**< Pointer to an array of device address pointers, pointing to addresses to be used in whitelist.

--- a/ble/Gap.h
+++ b/ble/Gap.h
@@ -51,7 +51,7 @@ public:
 
     /**
      * Address-type for BLEProtocol addresses.
-     * @note: deprecated. Use BLEProtocol::AddressType_t instead.
+     * @note: deprecated. Use @ref BLEProtocol::AddressType_t instead.
      *
      * DEPRECATION ALERT: The following constants have been left in their
      * deprecated state to transparenly support existing applications which may

--- a/ble/Gap.h
+++ b/ble/Gap.h
@@ -65,8 +65,8 @@ public:
     };
 
     static const unsigned ADDR_LEN = BLEProtocol::ADDR_LEN; /**< Length (in octets) of the BLE MAC address. */
-    typedef BLEProtocol::Address_t Address_t; /**< 48-bit address, LSB format. @Note: Deprecated. Use BLEProtocol::Address_t instead. */
-    typedef BLEProtocol::Address_t address_t; /**< 48-bit address, LSB format. @Note: Deprecated. Use BLEProtocol::Address_t instead. */
+    typedef BLEProtocol::AddressBytes_t Address_t; /**< 48-bit address, LSB format. @Note: Deprecated. Use BLEProtocol::AddressBytes_t instead. */
+    typedef BLEProtocol::AddressBytes_t address_t; /**< 48-bit address, LSB format. @Note: Deprecated. Use BLEProtocol::AddressBytes_t instead. */
 
 public:
     enum TimeoutSource_t {
@@ -113,7 +113,7 @@ public:
     };
 
     struct AdvertisementCallbackParams_t {
-        BLEProtocol::Address_t                   peerAddr;
+        BLEProtocol::AddressBytes_t              peerAddr;
         int8_t                                   rssi;
         bool                                     isScanResponse;
         GapAdvertisingParams::AdvertisingType_t  type;
@@ -126,9 +126,9 @@ public:
         Handle_t                    handle;
         Role_t                      role;
         BLEProtocol::AddressType_t  peerAddrType;
-        BLEProtocol::Address_t      peerAddr;
+        BLEProtocol::AddressBytes_t peerAddr;
         BLEProtocol::AddressType_t  ownAddrType;
-        BLEProtocol::Address_t      ownAddr;
+        BLEProtocol::AddressBytes_t ownAddr;
         const ConnectionParams_t   *connectionParams;
 
         ConnectionCallbackParams_t(Handle_t                    handleIn,
@@ -186,11 +186,11 @@ public:
 public:
     /**
      * Set the BTLE MAC address and type. Please note that the address format is
-     * least significant byte first (LSB). Please refer to BLEProtocol::Address_t.
+     * least significant byte first (LSB). Please refer to BLEProtocol::AddressBytes_t.
      *
      * @return BLE_ERROR_NONE on success.
      */
-    virtual ble_error_t setAddress(BLEProtocol::AddressType_t type, const BLEProtocol::Address_t address) {
+    virtual ble_error_t setAddress(BLEProtocol::AddressType_t type, const BLEProtocol::AddressBytes_t address) {
         /* avoid compiler warnings about unused variables */
         (void)type;
         (void)address;
@@ -203,7 +203,7 @@ public:
      *
      * @return BLE_ERROR_NONE on success.
      */
-    virtual ble_error_t getAddress(BLEProtocol::AddressType_t *typeP, BLEProtocol::Address_t address) {
+    virtual ble_error_t getAddress(BLEProtocol::AddressType_t *typeP, BLEProtocol::AddressBytes_t address) {
         /* Avoid compiler warnings about unused variables. */
         (void)typeP;
         (void)address;
@@ -262,10 +262,10 @@ public:
      *     successfully. The connectionCallChain (if set) will be invoked upon
      *     a connection event.
      */
-    virtual ble_error_t connect(const BLEProtocol::Address_t  peerAddr,
-                                BLEProtocol::AddressType_t    peerAddrType,
-                                const ConnectionParams_t     *connectionParams,
-                                const GapScanningParams      *scanParams) {
+    virtual ble_error_t connect(const BLEProtocol::AddressBytes_t  peerAddr,
+                                BLEProtocol::AddressType_t         peerAddrType,
+                                const ConnectionParams_t          *connectionParams,
+                                const GapScanningParams           *scanParams) {
         /* Avoid compiler warnings about unused variables. */
         (void)peerAddr;
         (void)peerAddrType;
@@ -1105,13 +1105,13 @@ protected:
 
     /* Entry points for the underlying stack to report events back to the user. */
 public:
-    void processConnectionEvent(Handle_t                      handle,
-                                Role_t                        role,
-                                BLEProtocol::AddressType_t    peerAddrType,
-                                const BLEProtocol::Address_t  peerAddr,
-                                BLEProtocol::AddressType_t    ownAddrType,
-                                const BLEProtocol::Address_t  ownAddr,
-                                const ConnectionParams_t     *connectionParams) {
+    void processConnectionEvent(Handle_t                           handle,
+                                Role_t                             role,
+                                BLEProtocol::AddressType_t         peerAddrType,
+                                const BLEProtocol::AddressBytes_t  peerAddr,
+                                BLEProtocol::AddressType_t         ownAddrType,
+                                const BLEProtocol::AddressBytes_t  ownAddr,
+                                const ConnectionParams_t          *connectionParams) {
         state.connected = 1;
         ConnectionCallbackParams_t callbackParams(handle, role, peerAddrType, peerAddr, ownAddrType, ownAddr, connectionParams);
         connectionCallChain.call(&callbackParams);
@@ -1123,7 +1123,7 @@ public:
         disconnectionCallChain.call(&callbackParams);
     }
 
-    void processAdvertisementReport(const BLEProtocol::Address_t             peerAddr,
+    void processAdvertisementReport(const BLEProtocol::AddressBytes_t        peerAddr,
                                     int8_t                                   rssi,
                                     bool                                     isScanResponse,
                                     GapAdvertisingParams::AdvertisingType_t  type,

--- a/ble/GapAdvertisingParams.h
+++ b/ble/GapAdvertisingParams.h
@@ -131,8 +131,25 @@ public:
     void setTimeout(uint16_t newTimeout)                         {_timeout   = newTimeout;  }
 
     /**
-     * Set the whiteList to be used for advertising. See \ref BLEProtocol::Whitelist_t
-     * @param [in] whiteList
+     * Set the whiteList to be used for advertising. See @ref
+     * BLEProtocol::Whitelist_t. When used for a Peripheral, both scan-requests
+     * and connection-requests are filtered by the white-list.
+     *
+     * @param [in] whiteList The white-list to be used for connections and scan-
+     *                 requests. If passed in as NULL, the existing whitelist
+     *                 (if any) remains in effect.
+     *
+     * @note The contents of the structure holding the white-list should remain
+     *     valid at least until advertising is started (in the case of the
+     *     Peripheral) or a connection-request is issued (in the case of the
+     *     Central).
+     *
+     * @note It is not possible to change the contents of the whitelist while it
+     *     is being used. For example, if the device is advertising and using
+     *     the whitelist to filter the devices to and from which it will respond
+     *     to scan requests or connection requests, the whitelist cannot be
+     *     changed until advertising is disabled. The whitelist can then be
+     *     changed and advertising re-enabled.
      */
     void setWhiteList(const BLEProtocol::Whitelist_t *whiteList) {_whiteList = whiteList;   }
 

--- a/ble/GapAdvertisingParams.h
+++ b/ble/GapAdvertisingParams.h
@@ -45,6 +45,9 @@ public:
     typedef enum AdvertisingType_t AdvertisingType; /* Deprecated type alias. */
 
 public:
+    /**
+     * Constructor for GapAdvertisingParams.
+     */
     GapAdvertisingParams(AdvertisingType_t               advType   = ADV_CONNECTABLE_UNDIRECTED,
                          uint16_t                        interval  = GAP_ADV_PARAMS_INTERVAL_MIN_NONCON,
                          uint16_t                        timeout   = 0,

--- a/ble/GapAdvertisingParams.h
+++ b/ble/GapAdvertisingParams.h
@@ -151,7 +151,7 @@ public:
      *     changed until advertising is disabled. The whitelist can then be
      *     changed and advertising re-enabled.
      */
-    void setWhiteList(const BLEProtocol::Whitelist_t *whiteList) {_whiteList = whiteList;   }
+    void setWhitelist(const BLEProtocol::Whitelist_t *whiteList) {_whiteList = whiteList;   }
 
 private:
     AdvertisingType_t               _advType;

--- a/ble/GapAdvertisingParams.h
+++ b/ble/GapAdvertisingParams.h
@@ -116,6 +116,16 @@ public:
         return _timeout;
     }
 
+    /**
+     * Accessor for whiteList.
+     *
+     * Typically used from the adaptation layer of the BLE port to pass
+     * parameters into the underlying stack.
+     */
+    const BLEProtocol::Whitelist_t *getWhiteList(void) const {
+        return _whiteList;
+    }
+
     void setAdvertisingType(AdvertisingType_t newAdvType)        {_advType   = newAdvType;  }
     void setInterval(uint16_t newInterval)                       {_interval  = MSEC_TO_ADVERTISEMENT_DURATION_UNITS(newInterval);}
     void setTimeout(uint16_t newTimeout)                         {_timeout   = newTimeout;  }

--- a/ble/GapAdvertisingParams.h
+++ b/ble/GapAdvertisingParams.h
@@ -17,6 +17,8 @@
 #ifndef __GAP_ADVERTISING_PARAMS_H__
 #define __GAP_ADVERTISING_PARAMS_H__
 
+#include "BLEProtocol.h"
+
 /**
  *  This class provides a wrapper for the core advertising parameters,
  *  including the advertising type (Connectable Undirected,
@@ -43,9 +45,13 @@ public:
     typedef enum AdvertisingType_t AdvertisingType; /* Deprecated type alias. */
 
 public:
-    GapAdvertisingParams(AdvertisingType_t advType  = ADV_CONNECTABLE_UNDIRECTED,
-                         uint16_t          interval = GAP_ADV_PARAMS_INTERVAL_MIN_NONCON,
-                         uint16_t          timeout  = 0) : _advType(advType), _interval(interval), _timeout(timeout) {
+    GapAdvertisingParams(AdvertisingType_t               advType   = ADV_CONNECTABLE_UNDIRECTED,
+                         uint16_t                        interval  = GAP_ADV_PARAMS_INTERVAL_MIN_NONCON,
+                         uint16_t                        timeout   = 0,
+                         const BLEProtocol::Whitelist_t *whiteList = NULL) : _advType(advType),
+                                                                             _interval(interval),
+                                                                             _timeout(timeout),
+                                                                             _whiteList(whiteList) {
         /* Interval checks. */
         if (_advType == ADV_CONNECTABLE_DIRECTED) {
             /* Interval must be 0 in directed connectable mode. */
@@ -107,14 +113,21 @@ public:
         return _timeout;
     }
 
-    void setAdvertisingType(AdvertisingType_t newAdvType) {_advType = newAdvType;  }
-    void setInterval(uint16_t newInterval)                {_interval = MSEC_TO_ADVERTISEMENT_DURATION_UNITS(newInterval);}
-    void setTimeout(uint16_t newTimeout)                  {_timeout = newTimeout;  }
+    void setAdvertisingType(AdvertisingType_t newAdvType)        {_advType   = newAdvType;  }
+    void setInterval(uint16_t newInterval)                       {_interval  = MSEC_TO_ADVERTISEMENT_DURATION_UNITS(newInterval);}
+    void setTimeout(uint16_t newTimeout)                         {_timeout   = newTimeout;  }
+
+    /**
+     * Set the whiteList to be used for advertising. See \ref BLEProtocol::Whitelist_t
+     * @param [in] whiteList
+     */
+    void setWhiteList(const BLEProtocol::Whitelist_t *whiteList) {_whiteList = whiteList;   }
 
 private:
-    AdvertisingType_t _advType;
-    uint16_t          _interval; /* In ADV duration units (i.e. 0.625ms). */
-    uint16_t          _timeout;  /* In seconds. */
+    AdvertisingType_t               _advType;
+    uint16_t                        _interval;  /* In ADV duration units (i.e. 0.625ms). */
+    uint16_t                        _timeout;   /* In seconds. */
+    const BLEProtocol::Whitelist_t *_whiteList; /**< white list associated with advertisements. \ref BLEProtocol::Whitelist_t */
 };
 
 #endif // ifndef __GAP_ADVERTISING_PARAMS_H__

--- a/ble/GapAdvertisingParams.h
+++ b/ble/GapAdvertisingParams.h
@@ -150,6 +150,8 @@ public:
      *     to scan requests or connection requests, the whitelist cannot be
      *     changed until advertising is disabled. The whitelist can then be
      *     changed and advertising re-enabled.
+     *
+     * @note this API is experimental.
      */
     void setWhitelist(const BLEProtocol::Whitelist_t *whiteList) {_whiteList = whiteList;   }
 

--- a/ble/GapScanningParams.h
+++ b/ble/GapScanningParams.h
@@ -90,7 +90,7 @@ private:
     uint16_t                        _window;         /**< Scan window in units of 625us (between 2.5ms and 10.24s). */
     uint16_t                        _timeout;        /**< Scan timeout between 0x0001 and 0xFFFF in seconds; 0x0000 disables timeout. */
     bool                            _activeScanning; /**< Obtain the peer device's advertising data and (if possible) scanResponse. */
-    const BLEProtocol::Whitelist_t *_whiteList;      /**< white list associated with advertisements. \ref BLEProtocol::Whitelist_t */
+    const BLEProtocol::Whitelist_t *_whiteList;      /**< white list associated with scanning. \ref BLEProtocol::Whitelist_t */
 
 private:
     /* Disallow copy constructor. */

--- a/ble/GapScanningParams.h
+++ b/ble/GapScanningParams.h
@@ -47,17 +47,50 @@ public:
 
 public:
     /* @Note: The following return durations in units of 0.625ms */
-    uint16_t getInterval(void) const {return _interval;}
-    uint16_t getWindow(void)   const {return _window;  }
+    uint16_t getInterval(void)       const {return _interval;      }
+    uint16_t getWindow(void)         const {return _window;        }
 
-    uint16_t getTimeout(void)  const {return _timeout; }
+    uint16_t getTimeout(void)        const {return _timeout;       }
     bool     getActiveScanning(void) const {return _activeScanning;}
 
+    /**
+     * Accessor for whiteList.
+     */
+    const BLEProtocol::Whitelist_t *getWhitelist(void) const {
+        return _whiteList;
+    }
+
+    /**
+     * Set the whiteList to be used for scanning. See @ref
+     * BLEProtocol::Whitelist_t. When used for a Central, advertisements are
+     * filtered by the white-list.
+     *
+     * @param [in] whiteList The white-list to be used for connections
+     *                 advertisements. If passed in as NULL, the existing
+     *                 whitelist (if any) remains in effect.
+     *
+     * @note The contents of the structure holding the white-list should remain
+     *     valid at least until scanning or a connection request is issued.
+     *
+     * @note It is not possible to change the contents of the whitelist while it
+     *     is being used. For example, if the device is waiting for a connection
+     *     and using the whitelist to filter the devices to and from which it
+     *     will respond, the whitelist cannot be changed until the
+     *     connection/scan request times out. The whitelist can then be changed
+     *     and scanning re-enabled.
+     *
+     * @note this API is experimental.
+     */
+    void setWhitelist(const BLEProtocol::Whitelist_t *whiteList) {
+        _whiteList = whiteList;
+    }
+
 private:
-    uint16_t _interval; /**< Scan interval in units of 625us (between 2.5ms and 10.24s). */
-    uint16_t _window;   /**< Scan window in units of 625us (between 2.5ms and 10.24s). */
-    uint16_t _timeout;  /**< Scan timeout between 0x0001 and 0xFFFF in seconds; 0x0000 disables timeout. */
-    bool     _activeScanning; /**< Obtain the peer device's advertising data and (if possible) scanResponse. */
+    uint16_t                        _interval;       /**< Scan interval in units of 625us (between 2.5ms and 10.24s). */
+    uint16_t                        _window;         /**< Scan window in units of 625us (between 2.5ms and 10.24s). */
+    uint16_t                        _timeout;        /**< Scan timeout between 0x0001 and 0xFFFF in seconds; 0x0000 disables timeout. */
+    bool                            _activeScanning; /**< Obtain the peer device's advertising data and (if possible) scanResponse. */
+    const BLEProtocol::Whitelist_t *_whiteList;      /**< white list associated with advertisements. \ref BLEProtocol::Whitelist_t */
 
 private:
     /* Disallow copy constructor. */


### PR DESCRIPTION
@pan- @andresag01 

I haven't been able to demonstrate this yet because I don't yet know the APIs to fetch IRKs used in the case of PRIVATE_RESOLVABLE_ADDRs.

refer to https://devzone.nordicsemi.com/question/53432/reading-irk-and-gap_evtparamsconnectedirk_match-issue/?answer=61656#post-id-61656