### PR TITLE
Clean up code in DiscoveredCharacteristic.cpp

### DIFF
--- a/source/DiscoveredCharacteristic.cpp
+++ b/source/DiscoveredCharacteristic.cpp
@@ -31,29 +31,29 @@ DiscoveredCharacteristic::read(uint16_t offset) const
     return gattc->read(connHandle, valueHandle, offset);
 }
 
-struct OneShotReadCallback { 
-    static void launch(GattClient* client, Gap::Handle_t connHandle, 
-                       GattAttribute::Handle_t handle, const GattClient::ReadCallback_t& cb) { 
+struct OneShotReadCallback {
+    static void launch(GattClient* client, Gap::Handle_t connHandle,
+                       GattAttribute::Handle_t handle, const GattClient::ReadCallback_t& cb) {
         OneShotReadCallback* oneShot = new OneShotReadCallback(client, connHandle, handle, cb);
         oneShot->attach();
         // delete will be made when this callback is called
     }
 
 private:
-    OneShotReadCallback(GattClient* client, Gap::Handle_t connHandle, 
-                        GattAttribute::Handle_t handle, const GattClient::ReadCallback_t& cb) : 
+    OneShotReadCallback(GattClient* client, Gap::Handle_t connHandle,
+                        GattAttribute::Handle_t handle, const GattClient::ReadCallback_t& cb) :
         _client(client),
         _connHandle(connHandle),
-        _handle(handle), 
-        _callback(cb) { } 
+        _handle(handle),
+        _callback(cb) { }
 
-    void attach() { 
+    void attach() {
         _client->onDataRead(makeFunctionPointer(this, &OneShotReadCallback::call));
     }
 
     void call(const GattReadCallbackParams* params) {
         // verifiy that it is the right characteristic on the right connection
-        if (params->connHandle == _connHandle && params->handle == _handle) { 
+        if (params->connHandle == _connHandle && params->handle == _handle) {
             _callback(params);
             _client->onDataRead().detach(makeFunctionPointer(this, &OneShotReadCallback::call));
             delete this;
@@ -68,7 +68,7 @@ private:
 
 ble_error_t DiscoveredCharacteristic::read(uint16_t offset, const GattClient::ReadCallback_t& onRead) const {
     ble_error_t error = read(offset);
-    if (error) { 
+    if (error) {
         return error;
     }
 
@@ -105,29 +105,29 @@ DiscoveredCharacteristic::writeWoResponse(uint16_t length, const uint8_t *value)
     return gattc->write(GattClient::GATT_OP_WRITE_CMD, connHandle, valueHandle, length, value);
 }
 
-struct OneShotWriteCallback { 
-    static void launch(GattClient* client, Gap::Handle_t connHandle, 
-                       GattAttribute::Handle_t handle, const GattClient::WriteCallback_t& cb) { 
+struct OneShotWriteCallback {
+    static void launch(GattClient* client, Gap::Handle_t connHandle,
+                       GattAttribute::Handle_t handle, const GattClient::WriteCallback_t& cb) {
         OneShotWriteCallback* oneShot = new OneShotWriteCallback(client, connHandle, handle, cb);
         oneShot->attach();
         // delete will be made when this callback is called
     }
 
 private:
-    OneShotWriteCallback(GattClient* client, Gap::Handle_t connHandle, 
-                        GattAttribute::Handle_t handle, const GattClient::WriteCallback_t& cb) : 
+    OneShotWriteCallback(GattClient* client, Gap::Handle_t connHandle,
+                        GattAttribute::Handle_t handle, const GattClient::WriteCallback_t& cb) :
         _client(client),
         _connHandle(connHandle),
-        _handle(handle), 
-        _callback(cb) { } 
+        _handle(handle),
+        _callback(cb) { }
 
-    void attach() { 
+    void attach() {
         _client->onDataWritten(makeFunctionPointer(this, &OneShotWriteCallback::call));
     }
 
     void call(const GattWriteCallbackParams* params) {
         // verifiy that it is the right characteristic on the right connection
-        if (params->connHandle == _connHandle && params->handle == _handle) { 
+        if (params->connHandle == _connHandle && params->handle == _handle) {
             _callback(params);
             _client->onDataWritten().detach(makeFunctionPointer(this, &OneShotWriteCallback::call));
             delete this;
@@ -142,7 +142,7 @@ private:
 
 ble_error_t DiscoveredCharacteristic::write(uint16_t length, const uint8_t *value, const GattClient::WriteCallback_t& onRead) const {
     ble_error_t error = write(length, value);
-    if (error) { 
+    if (error) {
         return error;
     }
 
@@ -154,5 +154,9 @@ ble_error_t DiscoveredCharacteristic::write(uint16_t length, const uint8_t *valu
 ble_error_t
 DiscoveredCharacteristic::discoverDescriptors(DescriptorCallback_t callback, const UUID &matchingUUID) const
 {
+    /* Avoid compiler warnings */
+    (void) callback;
+    (void) matchingUUID;
+
     return BLE_ERROR_NOT_IMPLEMENTED; /* TODO: this needs to be filled in. */
 }


### PR DESCRIPTION
Clean up the code by removing white spaces and adding statements to suppress
unused-parameter compiler warnings.
@rgrover @LiyouZhou @pan- 