### PR TITLE
Whitelisting experimental API

### DIFF
--- a/ble/BLE.h
+++ b/ble/BLE.h
@@ -752,10 +752,10 @@ public:
      * ble.connect(...) should be replaced with
      * ble.gap().connect(...).
      */
-    ble_error_t connect(const BLEProtocol::AddressBytes_t   peerAddr,
-                        BLEProtocol::AddressType_t     peerAddrType = BLEProtocol::AddressType::RANDOM_STATIC,
-                        const Gap::ConnectionParams_t *connectionParams = NULL,
-                        const GapScanningParams       *scanParams = NULL) {
+    ble_error_t connect(const BLEProtocol::AddressBytes_t  peerAddr,
+                        BLEProtocol::AddressType_t         peerAddrType = BLEProtocol::AddressType::RANDOM_STATIC,
+                        const Gap::ConnectionParams_t     *connectionParams = NULL,
+                        const GapScanningParams           *scanParams = NULL) {
         return gap().connect(peerAddr, peerAddrType, connectionParams, scanParams);
     }
 

--- a/ble/BLE.h
+++ b/ble/BLE.h
@@ -239,7 +239,7 @@ public:
      * ble.setAddress(...) should be replaced with
      * ble.gap().setAddress(...).
      */
-    ble_error_t setAddress(BLEProtocol::AddressType_t type, const BLEProtocol::Address_t address) {
+    ble_error_t setAddress(BLEProtocol::AddressType_t type, const BLEProtocol::AddressBytes_t address) {
         return gap().setAddress(type, address);
     }
 
@@ -252,7 +252,7 @@ public:
      * ble.getAddress(...) should be replaced with
      * ble.gap().getAddress(...).
      */
-    ble_error_t getAddress(BLEProtocol::AddressType_t *typeP, BLEProtocol::Address_t address) {
+    ble_error_t getAddress(BLEProtocol::AddressType_t *typeP, BLEProtocol::AddressBytes_t address) {
         return gap().getAddress(typeP, address);
     }
 
@@ -752,7 +752,7 @@ public:
      * ble.connect(...) should be replaced with
      * ble.gap().connect(...).
      */
-    ble_error_t connect(const BLEProtocol::Address_t   peerAddr,
+    ble_error_t connect(const BLEProtocol::AddressBytes_t   peerAddr,
                         BLEProtocol::AddressType_t     peerAddrType = BLEProtocol::AddressType::RANDOM_STATIC,
                         const Gap::ConnectionParams_t *connectionParams = NULL,
                         const GapScanningParams       *scanParams = NULL) {

--- a/ble/BLEProtocol.h
+++ b/ble/BLEProtocol.h
@@ -26,15 +26,19 @@
  * A common namespace for types and constants used everywhere in BLE API.
  */
 namespace BLEProtocol {
-    /**< Address-type for Protocol addresses. */
-    struct AddressType { /* Adding a struct to encapsulate the contained enumeration
-                          * prevents polluting the BLEProtocol namespace with the
-                          * enumerated values. It also allows type-aliases for the
-                          * enumeration while retaining the enumerated values. i.e.
-                          *
-                          * doing:
-                          *       typedef AddressType_t AliasedType_t;
-                          * would allow the use of AliasedType_t::PUBLIC in code. */
+    /**<
+     * A simple container for the enumeration of address-types for Protocol addresses.
+     *
+     * Adding a struct to encapsulate the contained enumeration prevents
+     * polluting the BLEProtocol namespace with the enumerated values. It also
+     * allows type-aliases for the enumeration while retaining the enumerated
+     * values. i.e. doing:
+     *       typedef AddressType AliasedType;
+     *
+     * would allow the use of AliasedType::PUBLIC in code.
+     */
+    struct AddressType {
+        /**< Address-types for Protocol addresses. */
         enum Type {
             PUBLIC = 0,
             RANDOM_STATIC,
@@ -42,10 +46,10 @@ namespace BLEProtocol {
             RANDOM_PRIVATE_NON_RESOLVABLE
         };
     };
-    typedef AddressType::Type AddressType_t; /**< Alias for AddressType::Type */
+    typedef AddressType::Type AddressType_t;  /**< Alias for AddressType::Type */
 
-    static const size_t ADDR_LEN = 6;        /**< Length (in octets) of the BLE MAC address. */
-    typedef uint8_t AddressBytes_t[ADDR_LEN];     /**< 48-bit address, in LSB format. */
+    static const size_t ADDR_LEN = 6;         /**< Length (in octets) of the BLE MAC address. */
+    typedef uint8_t AddressBytes_t[ADDR_LEN]; /**< 48-bit address, in LSB format. */
 
     /**
      * BLE address. It contains an address-type (@ref AddressType_t) and bytes (@ref AddressBytes_t).
@@ -58,16 +62,7 @@ namespace BLEProtocol {
             std::copy(addressIn, addressIn + ADDR_LEN, address);
         }
 
-        Address_t(void) : type(AddressType::PUBLIC), address() {
-        }
-
-        bool operator<(const Address_t &rhs) const {
-            if (type < rhs.type) {
-                return true;
-            } else if (type > rhs.type) {
-                return false;
-            }
-            return (memcmp(address, rhs.address, sizeof(AddressBytes_t)) < 0) ? true : false;
+        Address_t() : type(), address() {
         }
     };
 };

--- a/ble/BLEProtocol.h
+++ b/ble/BLEProtocol.h
@@ -20,7 +20,6 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <algorithm>
-#include <string.h>
 
 /**
  * A common namespace for types and constants used everywhere in BLE API.

--- a/ble/BLEProtocol.h
+++ b/ble/BLEProtocol.h
@@ -19,6 +19,8 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <algorithm>
+#include <string.h>
 
 /**
  * A common namespace for types and constants used everywhere in BLE API.
@@ -43,7 +45,31 @@ namespace BLEProtocol {
     typedef AddressType::Type AddressType_t; /**< Alias for AddressType::Type */
 
     static const size_t ADDR_LEN = 6;        /**< Length (in octets) of the BLE MAC address. */
-    typedef uint8_t Address_t[ADDR_LEN];     /**< 48-bit address, in LSB format. */
+    typedef uint8_t AddressBytes_t[ADDR_LEN];     /**< 48-bit address, in LSB format. */
+
+    /**
+     * BLE address. It contains an address-type (@ref AddressType_t) and bytes (@ref AddressBytes_t).
+     */
+    struct Address_t {
+        AddressType_t  type;    /**< @ref AddressType_t */
+        AddressBytes_t address; /**< @ref AddressBytes_t */
+
+        Address_t(AddressType_t typeIn, const AddressBytes_t& addressIn) : type(typeIn) {
+            std::copy(addressIn, addressIn + ADDR_LEN, address);
+        }
+
+        Address_t(void) : type(AddressType::PUBLIC), address() {
+        }
+
+        bool operator<(const Address_t &rhs) const {
+            if (type < rhs.type) {
+                return true;
+            } else if (type > rhs.type) {
+                return false;
+            }
+            return (memcmp(address, rhs.address, sizeof(AddressBytes_t)) < 0) ? true : false;
+        }
+    };
 };
 
 #endif /* __BLE_PROTOCOL_H__ */

--- a/ble/Gap.h
+++ b/ble/Gap.h
@@ -129,6 +129,7 @@ public:
     struct Whitelist_t {
         BLEProtocol::Address_t *addresses;
         uint8_t                 size;
+        uint8_t                 capacity;
     };
 
 
@@ -524,7 +525,7 @@ public:
      * advertising or initiating a connection depending on the filter policies.
      *
      * @param[in/out]   whitelist
-     *                  (on input) whitelist.size contains the maximum number
+     *                  (on input) whitelist.capacity contains the maximum number
      *                  of addresses to be returned.
      *                  (on output) The populated whitelist with copies of the
      *                  addresses in the implementation's whitelist.

--- a/ble/Gap.h
+++ b/ble/Gap.h
@@ -97,6 +97,8 @@ public:
      * Enumeration for whitelist advertising policy filter modes. The possible
      * filter modes were obtained from the Bluetooth Core Specification
      * 4.2 (Vol. 6), Part B, Section 4.3.2.
+     *
+     * @experimental
      */
     enum AdvertisingPolicyMode_t {
         ADV_POLICY_IGNORE_WHITELIST = 0,
@@ -109,6 +111,8 @@ public:
      * Enumeration for whitelist scanning policy filter modes. The possible
      * filter modes were obtained from the Bluetooth Core Specification
      * 4.2 (Vol. 6), Part B, Section 4.3.3.
+     *
+     * @experimental
      */
     enum ScanningPolicyMode_t {
         SCAN_POLICY_IGNORE_WHITELIST = 0,
@@ -119,13 +123,19 @@ public:
      * Enumeration for the whitelist initiator policy fiter modes. The possible
      * filter modes were obtained from the Bluetooth Core Specification
      * 4.2 (vol. 6), Part B, Section 4.4.4.
+     *
+     * @experimental
      */
     enum InitiatorPolicyMode_t {
         INIT_POLICY_IGNORE_WHITELIST = 0,
         INIT_POLICY_FILTER_ALL_ADV   = 1,
     };
 
-    /* Representation of a Bluetooth Low Enery Whitelist containing addresses. */
+    /**
+     * Representation of a Bluetooth Low Enery Whitelist containing addresses.
+     *
+     * @experimental
+     */
     struct Whitelist_t {
         BLEProtocol::Address_t *addresses;
         uint8_t                 size;
@@ -514,6 +524,8 @@ public:
 
     /**
      * @return Maximum size of the whitelist.
+     *
+     * @experimental
      */
     virtual uint8_t getMaxWhitelistSize(void) const
     {
@@ -532,6 +544,8 @@ public:
      *
      * @return BLE_ERROR_NONE if the implementation's whitelist was successfully
      *         copied into the supplied reference.
+     *
+     * @experimental
      */
     virtual ble_error_t getWhitelist(Whitelist_t &whitelist) const
     {
@@ -557,6 +571,8 @@ public:
      *       is not possible to resolve it.
      * @note If the input whitelist is larger than @ref getMaxWhitelistSize()
      *       the @ref BLE_ERROR_PARAM_OUT_OF_RANGE is returned.
+     *
+     * @experimental
      */
     virtual ble_error_t setWhitelist(const Whitelist_t &whitelist)
     {
@@ -570,6 +586,8 @@ public:
      *
      * @param[in] mode
      *              The new advertising policy filter mode.
+     *
+     * @experimental
      */
     virtual void setAdvertisingPolicyMode(AdvertisingPolicyMode_t mode)
     {
@@ -582,6 +600,8 @@ public:
      *
      * @param[in] mode
      *              The new scan policy filter mode.
+     *
+     * @experimental
      */
     virtual void setScanningPolicyMode(ScanningPolicyMode_t mode)
     {
@@ -593,6 +613,8 @@ public:
      *
      * @param[in] mode
      *              The new initiator policy filter mode.
+     *
+     * @experimental
      */
     virtual void setInitiatorPolicyMode(InitiatorPolicyMode_t mode)
     {
@@ -604,6 +626,8 @@ public:
      * call to startAdvertising().
      *
      * @return The set advertising policy filter mode.
+     *
+     * @experimental
      */
     virtual AdvertisingPolicyMode_t getAdvertisingPolicyMode(void) const
     {
@@ -615,6 +639,8 @@ public:
      * call to startScan().
      *
      * @return The set scan policy filter mode.
+     *
+     * @experimental
      */
     virtual ScanningPolicyMode_t getScanningPolicyMode(void) const
     {
@@ -625,6 +651,8 @@ public:
      * Get the initiator policy filter mode that will be used.
      *
      * @return The set scan policy filter mode.
+     *
+     * @experimental
      */
     virtual InitiatorPolicyMode_t getInitiatorPolicyMode(void) const
     {

--- a/ble/Gap.h
+++ b/ble/Gap.h
@@ -66,8 +66,8 @@ public:
     };
 
     static const unsigned ADDR_LEN = BLEProtocol::ADDR_LEN; /**< Length (in octets) of the BLE MAC address. */
-    typedef BLEProtocol::AddressBytes_t Address_t; /**< 48-bit address, LSB format. @Note: Deprecated. Use BLEProtocol::Address_t instead. */
-    typedef BLEProtocol::AddressBytes_t address_t; /**< 48-bit address, LSB format. @Note: Deprecated. Use BLEProtocol::Address_t instead. */
+    typedef BLEProtocol::AddressBytes_t Address_t; /**< 48-bit address, LSB format. @Note: Deprecated. Use BLEProtocol::AddressBytes_t instead. */
+    typedef BLEProtocol::AddressBytes_t address_t; /**< 48-bit address, LSB format. @Note: Deprecated. Use BLEProtocol::AddressBytes_t instead. */
 
 public:
     enum TimeoutSource_t {
@@ -141,9 +141,9 @@ public:
     typedef uint16_t Handle_t; /* Type for connection handle. */
 
     typedef struct {
-        uint16_t minConnectionInterval;      /**< Minimum Connection Interval in 1.25 ms units, see @ref BLE_GAP_CP_LIMITS.*/
-        uint16_t maxConnectionInterval;      /**< Maximum Connection Interval in 1.25 ms units, see @ref BLE_GAP_CP_LIMITS.*/
-        uint16_t slaveLatency;               /**< Slave Latency in number of connection events, see @ref BLE_GAP_CP_LIMITS.*/
+        uint16_t minConnectionInterval;        /**< Minimum Connection Interval in 1.25 ms units, see @ref BLE_GAP_CP_LIMITS.*/
+        uint16_t maxConnectionInterval;        /**< Maximum Connection Interval in 1.25 ms units, see @ref BLE_GAP_CP_LIMITS.*/
+        uint16_t slaveLatency;                 /**< Slave Latency in number of connection events, see @ref BLE_GAP_CP_LIMITS.*/
         uint16_t connectionSupervisionTimeout; /**< Connection Supervision Timeout in 10 ms units, see @ref BLE_GAP_CP_LIMITS.*/
     } ConnectionParams_t;
 
@@ -166,9 +166,9 @@ public:
         Handle_t                    handle;
         Role_t                      role;
         BLEProtocol::AddressType_t  peerAddrType;
-        BLEProtocol::AddressBytes_t      peerAddr;
+        BLEProtocol::AddressBytes_t peerAddr;
         BLEProtocol::AddressType_t  ownAddrType;
-        BLEProtocol::AddressBytes_t      ownAddr;
+        BLEProtocol::AddressBytes_t ownAddr;
         const ConnectionParams_t   *connectionParams;
 
         ConnectionCallbackParams_t(Handle_t                    handleIn,
@@ -226,7 +226,7 @@ public:
 public:
     /**
      * Set the BTLE MAC address and type. Please note that the address format is
-     * least significant byte first (LSB). Please refer to BLEProtocol::Address_t.
+     * least significant byte first (LSB). Please refer to BLEProtocol::AddressBytes_t.
      *
      * @return BLE_ERROR_NONE on success.
      */
@@ -1291,13 +1291,13 @@ protected:
 
     /* Entry points for the underlying stack to report events back to the user. */
 public:
-    void processConnectionEvent(Handle_t                      handle,
-                                Role_t                        role,
-                                BLEProtocol::AddressType_t    peerAddrType,
+    void processConnectionEvent(Handle_t                           handle,
+                                Role_t                             role,
+                                BLEProtocol::AddressType_t         peerAddrType,
                                 const BLEProtocol::AddressBytes_t  peerAddr,
-                                BLEProtocol::AddressType_t    ownAddrType,
+                                BLEProtocol::AddressType_t         ownAddrType,
                                 const BLEProtocol::AddressBytes_t  ownAddr,
-                                const ConnectionParams_t     *connectionParams) {
+                                const ConnectionParams_t          *connectionParams) {
         state.connected = 1;
         ConnectionCallbackParams_t callbackParams(handle, role, peerAddrType, peerAddr, ownAddrType, ownAddr, connectionParams);
         connectionCallChain.call(&callbackParams);
@@ -1309,7 +1309,7 @@ public:
         disconnectionCallChain.call(&callbackParams);
     }
 
-    void processAdvertisementReport(const BLEProtocol::AddressBytes_t             peerAddr,
+    void processAdvertisementReport(const BLEProtocol::AddressBytes_t        peerAddr,
                                     int8_t                                   rssi,
                                     bool                                     isScanResponse,
                                     GapAdvertisingParams::AdvertisingType_t  type,

--- a/ble/Gap.h
+++ b/ble/Gap.h
@@ -516,7 +516,7 @@ public:
      */
     virtual uint8_t getMaxWhitelistSize(void) const
     {
-        return BLE_ERROR_NOT_IMPLEMENTED;
+        return 0;
     }
 
     /**
@@ -542,7 +542,7 @@ public:
      * Set the internal whitelist to be used by the Link Layer when scanning,
      * advertising or initiating a connection depending on the filter policies.
      *
-     * @param[out]    whitelist
+     * @param[in]     whitelist
      *                  A reference to a whitelist containing the addresses to
      *                  be added to the internal whitelist.
      *
@@ -557,7 +557,7 @@ public:
      * @note If the input whitelist is larger than @ref getMaxWhitelistSize()
      *       the @ref BLE_ERROR_PARAM_OUT_OF_RANGE is returned.
      */
-    virtual ble_error_t setWhitelist(Whitelist_t &whitelist)
+    virtual ble_error_t setWhitelist(const Whitelist_t &whitelist)
     {
         (void) whitelist;
         return BLE_ERROR_NOT_IMPLEMENTED;

--- a/ble/Gap.h
+++ b/ble/Gap.h
@@ -115,7 +115,7 @@ public:
     };
 
     struct AdvertisementCallbackParams_t {
-        BLEProtocol::AddressBytes_t                   peerAddr;
+        BLEProtocol::AddressBytes_t              peerAddr;
         int8_t                                   rssi;
         bool                                     isScanResponse;
         GapAdvertisingParams::AdvertisingType_t  type;
@@ -265,9 +265,9 @@ public:
      *     a connection event.
      */
     virtual ble_error_t connect(const BLEProtocol::AddressBytes_t  peerAddr,
-                                BLEProtocol::AddressType_t    peerAddrType,
-                                const ConnectionParams_t     *connectionParams,
-                                const GapScanningParams      *scanParams) {
+                                BLEProtocol::AddressType_t         peerAddrType,
+                                const ConnectionParams_t          *connectionParams,
+                                const GapScanningParams           *scanParams) {
         /* Avoid compiler warnings about unused variables. */
         (void)peerAddr;
         (void)peerAddrType;
@@ -286,10 +286,10 @@ public:
                                                         const GapScanningParams      *scanParams)
      *      to maintain backward compatibility for change from Gap::AddressType_t to BLEProtocol::AddressType_t
      */
-    ble_error_t connect(const BLEProtocol::Address_t  peerAddr,
-                        DeprecatedAddressType_t       peerAddrType,
-                        const ConnectionParams_t     *connectionParams,
-                        const GapScanningParams      *scanParams)
+    ble_error_t connect(const BLEProtocol::AddressBytes_t  peerAddr,
+                        DeprecatedAddressType_t            peerAddrType,
+                        const ConnectionParams_t          *connectionParams,
+                        const GapScanningParams           *scanParams)
     __deprecated_message("Gap::DeprecatedAddressType_t is deprecated, use BLEProtocol::AddressType_t instead") {
         return connect(peerAddr, (BLEProtocol::AddressType_t) peerAddrType, connectionParams, scanParams);
     }

--- a/ble/Gap.h
+++ b/ble/Gap.h
@@ -587,11 +587,15 @@ public:
      * @param[in] mode
      *              The new advertising policy filter mode.
      *
+     * @return BLE_ERROR_NONE if the specified policy filter mode was set
+     *         successfully.
+     *
      * @experimental
      */
-    virtual void setAdvertisingPolicyMode(AdvertisingPolicyMode_t mode)
+    virtual ble_error_t setAdvertisingPolicyMode(AdvertisingPolicyMode_t mode)
     {
         (void) mode;
+        return BLE_ERROR_NOT_IMPLEMENTED;
     }
 
     /**
@@ -601,11 +605,15 @@ public:
      * @param[in] mode
      *              The new scan policy filter mode.
      *
+     * @return BLE_ERROR_NONE if the specified policy filter mode was set
+     *         successfully.
+     *
      * @experimental
      */
-    virtual void setScanningPolicyMode(ScanningPolicyMode_t mode)
+    virtual ble_error_t setScanningPolicyMode(ScanningPolicyMode_t mode)
     {
         (void) mode;
+        return BLE_ERROR_NOT_IMPLEMENTED;
     }
 
     /**
@@ -614,11 +622,15 @@ public:
      * @param[in] mode
      *              The new initiator policy filter mode.
      *
+     * @return BLE_ERROR_NONE if the specified policy filter mode was set
+     *         successfully.
+     *
      * @experimental
      */
-    virtual void setInitiatorPolicyMode(InitiatorPolicyMode_t mode)
+    virtual ble_error_t setInitiatorPolicyMode(InitiatorPolicyMode_t mode)
     {
         (void) mode;
+        return BLE_ERROR_NOT_IMPLEMENTED;
     }
 
     /**


### PR DESCRIPTION
This is the finilised experimental API that introduces support for
whitelisting. The changes are focused in Gap and introduces the following
functions, that are expected to be implemented by each of the vendor specific
glue code (e.g. ble-nrf51822 module):

- getMaxWhitelistSize(): Get the maximum whitelist size, this can be set by
  using a yotta config definition.
- getWhitelist(): Gets a copy of the internal whitelist containing BLE
  addresses.
- setWhitelist(): Replace the whitelist with new addresses.
- setAdvertisingPolicyMode(), setScanningPolicyMode() and
  setInitiatorPolicyMode(): Functions used to set the relevan policy filter
  mode as described in the BLE Specification v4.2 Vol 6, Part B, Section 4.2.1.
- getAdvertisingPolicyMode(), getScanningPolicyMode() and
  getInitiatorPolicyMode(): Functions used to get the relevan policy filter
  mode as described in the BLE Specification v4.2 Vol 6, Part B, Section 4.2.1.

The following enumerators were added to Gap to describe the desired policy
filter mode:

- AdvertisingPolicyMode_t
- ScanningPolicyMode_t
- InitiatorPolicyMode_t

Finally, the following typedef was added to provide a view of the
underlying implementation's internal whitelist:

- Whitelist_t

**NOTE:** Clearly, these API additions require changes to the underlying
implementation!

**NOTE:** Changes related to BLEProtocol::Address_t and BLEProtocol::AddressBytes_t are from @rgrover  in [this pull request](https://github.com/ARMmbed/ble/pull/151).

@pan- 