### PR TITLE
Add API to get addresses of peers in bond table

### DIFF
--- a/ble/SecurityManager.h
+++ b/ble/SecurityManager.h
@@ -175,6 +175,8 @@ public:
      * @retval BLE_ERROR_NONE             On success, else an error code indicating reason for failure.
      * @retval BLE_ERROR_INVALID_STATE    If the API is called without module initialization or
      *                                    application registration.
+     *
+     * @experimental
      */
     virtual ble_error_t getAddressesFromBondTable(Gap::Whitelist_t &addresses) const {
         /* Avoid compiler warnings about unused variables */

--- a/ble/SecurityManager.h
+++ b/ble/SecurityManager.h
@@ -176,7 +176,7 @@ public:
      * @retval BLE_ERROR_INVALID_STATE    If the API is called without module initialization or
      *                                    application registration.
      */
-    virtual ble_error_t getAddressesFromBondTable(Gap::Whitelist_t &addresses) {
+    virtual ble_error_t getAddressesFromBondTable(Gap::Whitelist_t &addresses) const {
         /* Avoid compiler warnings about unused variables */
         (void) addresses;
 

--- a/ble/SecurityManager.h
+++ b/ble/SecurityManager.h
@@ -163,6 +163,26 @@ public:
         return BLE_ERROR_NOT_IMPLEMENTED; /* Requesting action from porters: override this API if security is supported. */
     }
 
+    /**
+     * Get a list of addresses from all peers in the bond table.
+     *
+     * @param[in/out]   addresses
+     *                  (on input) addresses.capacity contains the maximum
+     *                  number of addresses to be returned.
+     *                  (on output) The populated table with copies of the
+     *                  addresses in the implementation's whitelist.
+     *
+     * @retval BLE_ERROR_NONE             On success, else an error code indicating reason for failure.
+     * @retval BLE_ERROR_INVALID_STATE    If the API is called without module initialization or
+     *                                    application registration.
+     */
+    virtual ble_error_t getAddressesFromBondTable(Gap::Whitelist_t &addresses) {
+        /* Avoid compiler warnings about unused variables */
+        (void) addresses;
+
+        return BLE_ERROR_NOT_IMPLEMENTED; /* Requesting action from porters: override this API if security is supported. */
+    }
+
     /* Event callback handlers. */
 public:
     /**


### PR DESCRIPTION
The new API is added to the Security Manager. Its declaration is as follows:

virtual ble_error_t getAddressesFromBondTable(Gap::Whitelist_t &addresses)

The resulting Whitelist_t structure can then be used as the actual whitelist
passes to Gap::setWhitelist().

Note that for peers that have private resolvable addresses, then an address of
the same type will be returned.
@pan- 