### PR TITLE
Update Gap state after advertising times out

### DIFF
--- a/ble/Gap.h
+++ b/ble/Gap.h
@@ -1367,6 +1367,10 @@ public:
     }
 
     void processTimeoutEvent(TimeoutSource_t source) {
+        if (source == TIMEOUT_SRC_ADVERTISING) {
+            /* Update gap state if the source is an advertising timeout */
+            state.advertising = 0;
+        }
         if (timeoutCallbackChain) {
             timeoutCallbackChain(source);
         }


### PR DESCRIPTION
The BLE API was not updating the Gap internal state when the advertising stops
because of a user timeout. This commit fixes the issue by updating the internal
state structure in Gap just before the registered callbacks are notified of the
advertising timeout.
@pan- 