### PR TITLE
Update Gap state after advertising times out

### DIFF
--- a/ble/Gap.h
+++ b/ble/Gap.h
@@ -1295,6 +1295,7 @@ public:
         /* Clear Gap state */
         state.advertising = 0;
         state.connected   = 0;
+        connectionCount   = 0;
 
         /* Clear scanning state */
         scanningActive = false;
@@ -1319,6 +1320,7 @@ protected:
         _advPayload(),
         _scanningParams(),
         _scanResponse(),
+        connectionCount(0),
         state(),
         scanningActive(false),
         timeoutCallbackChain(),
@@ -1339,13 +1341,22 @@ public:
                                 BLEProtocol::AddressType_t         ownAddrType,
                                 const BLEProtocol::AddressBytes_t  ownAddr,
                                 const ConnectionParams_t          *connectionParams) {
-        state.connected = 1;
+        /* Update Gap state */
+        state.advertising = 0;
+        state.connected   = 1;
+        ++connectionCount;
+
         ConnectionCallbackParams_t callbackParams(handle, role, peerAddrType, peerAddr, ownAddrType, ownAddr, connectionParams);
         connectionCallChain.call(&callbackParams);
     }
 
     void processDisconnectionEvent(Handle_t handle, DisconnectionReason_t reason) {
-        state.connected = 0;
+        /* Update Gap state */
+        --connectionCount;
+        if (!connectionCount) {
+            state.connected = 0;
+        }
+
         DisconnectionCallbackParams_t callbackParams(handle, reason);
         disconnectionCallChain.call(&callbackParams);
     }
@@ -1382,6 +1393,10 @@ protected:
     GapScanningParams                _scanningParams;
     GapAdvertisingData               _scanResponse;
 
+    /**
+     * Total number of open connections.
+     */
+    uint8_t                          connectionCount;
     GapState_t                       state;
     bool                             scanningActive;
 

--- a/ble/Gap.h
+++ b/ble/Gap.h
@@ -1367,6 +1367,10 @@ public:
     }
 
     void processTimeoutEvent(TimeoutSource_t source) {
+        if (source == TIMEOUT_SRC_ADVERTISING) {
+            /* Update gap state if the source is an advertising timeout */
+            state.advertising = 0;
+        }
         if (timeoutCallbackChain) {
             timeoutCallbackChain(source);
         }


### PR DESCRIPTION
The BLE API was not updating the Gap internal state when the advertising stops
because of a user timeout. This commit fixes the issue by updating the internal
state structure in Gap just before the registered callbacks are notified of the
advertising timeout.
@pan- 