### PR TITLE
Update Gap state in startAdvertising()

### DIFF
--- a/ble/Gap.h
+++ b/ble/Gap.h
@@ -741,8 +741,12 @@ public:
      * Start advertising.
      */
     ble_error_t startAdvertising(void) {
+        ble_error_t rc;
         setAdvertisingData(); /* Update the underlying stack. */
-        return startAdvertising(_advParams);
+        if ((rc = startAdvertising(_advParams)) == BLE_ERROR_NONE) {
+            state.advertising = 1;
+        }
+        return rc;
     }
 
     /**


### PR DESCRIPTION
Update the Gap::state in Gap itself rather than the implementation. There is an associated pull request in ble-nrf51822: https://github.com/ARMmbed/ble-nrf51822/pull/108.

@pan- 