### PR TITLE
Invalid adv payloads are not committed before checking

### DIFF
--- a/ble/Gap.h
+++ b/ble/Gap.h
@@ -1118,12 +1118,11 @@ public:
      */
     ble_error_t setAdvertisingPayload(const GapAdvertisingData &payload) {
         ble_error_t rc = setAdvertisingData(_advPayload, _scanResponse);
-        if (rc != BLE_ERROR_NONE) {
-            /* The payload has a problem, do not store it */
-            return rc;
+        if (rc == BLE_ERROR_NONE) {
+            _advPayload = payload;
         }
-        _advPayload = payload;
-        return BLE_ERROR_NONE;
+
+        return rc;
     }
 
     /**

--- a/ble/Gap.h
+++ b/ble/Gap.h
@@ -1020,16 +1020,18 @@ public:
      *         advertising payload.
      */
     ble_error_t accumulateAdvertisingPayloadTxPower(int8_t power) {
-        if (power < -100 || power > 20) {
-            return BLE_ERROR_PARAM_OUT_OF_RANGE;
-        }
-
+        GapAdvertisingData advPayloadCopy = _advPayload;
         ble_error_t rc;
-        if ((rc = _advPayload.addTxPower(power)) != BLE_ERROR_NONE) {
+        if ((rc = advPayloadCopy.addTxPower(power)) != BLE_ERROR_NONE) {
             return rc;
         }
 
-        return setAdvertisingData(_advPayload, _scanResponse);
+        rc = setAdvertisingData(advPayloadCopy, _scanResponse);
+        if (rc == BLE_ERROR_NONE) {
+            _advPayload = advPayloadCopy;
+        }
+
+        return rc;
     }
 
     /**

--- a/ble/Gap.h
+++ b/ble/Gap.h
@@ -848,7 +848,6 @@ public:
         return INIT_POLICY_IGNORE_WHITELIST;
     }
 
-
 protected:
     /* Override the following in the underlying adaptation layer to provide the functionality of scanning. */
 

--- a/ble/Gap.h
+++ b/ble/Gap.h
@@ -938,7 +938,6 @@ public:
      * @return BLE_ERROR_NONE if the device started advertising successfully.
      */
     ble_error_t startAdvertising(void) {
-        setAdvertisingData(); /* Update the underlying stack. */
         return startAdvertising(_advParams);
     }
 


### PR DESCRIPTION
Invalid advertising payloads are no longer committed to the local copy of the advertising and scan payloads in BLE API before the contents are checked by the underlying stack. The Gap member functions changed are:

* accumulateAdvertisingPayload(flags)
* accumulateAdvertisingPayload(appearance)
* accumulateAdvertisingPayloadTxPower(power)
* accumulateAdvertisingPayload(type, data, length)
* updateAdvertisingPayload(type, data, length)
* setAdvertisingPayload(newPayload)
* accumulateScanResponse(type, data, length)

Furthermore, startAdvertising() no longer sets the payload in the underlying stack because the payload is set every time it is updated. Finally, the shorthand private member setAdvertisingData(void) is removed from Gap as it is redundant.
@pan- 