### PR TITLE
Initial version of the setCCCD API for GattClient

### DIFF
--- a/ble/CCCDSetter.h
+++ b/ble/CCCDSetter.h
@@ -1,0 +1,105 @@
+#include "FunctionPointerWithContext.h"
+#include "GattClient.h"
+#include "GattAttribute.h"
+#include "DiscoveredCharacteristic.h"
+#include "CharacteristicDescriptorDiscovery.h"
+
+#ifndef __CCCDSETTER_H__
+#define __CCCDSETTER_H__
+
+class CCCDSetter {
+public:
+    static void launch(GattClient* client,
+                       const DiscoveredCharacteristic &characteristic,
+                       const GattClient::WriteCallback_t& callback,
+                       uint16_t cccdData) {
+        CCCDSetter* cccdSetterPtr = new CCCDSetter(client, characteristic, callback, cccdData);
+        cccdSetterPtr->attach();
+    }
+
+private:
+    CCCDSetter(GattClient* client,
+               const DiscoveredCharacteristic &characteristic,
+               const GattClient::WriteCallback_t& callback,
+               uint16_t cccdData) :
+        _client(client),
+        _characteristic(characteristic),
+        _callback(callback),
+        _cccdData(cccdData),
+        _cccdFound(false) { }
+
+    void attach(void) {
+        /* Launch descriptor discovery procedure */
+        FunctionPointerWithContext<const CharacteristicDescriptorDiscovery::DiscoveryCallbackParams_t*> descriptorDiscoveredCallback(this, &CCCDSetter::descriptorDiscovered);
+        FunctionPointerWithContext<const CharacteristicDescriptorDiscovery::TerminationCallbackParams_t*> descriptorDiscoveryTerminationCallback(this, &CCCDSetter::descriptorDiscoveryTermination);
+        _characteristic.discoverDescriptors(descriptorDiscoveredCallback, descriptorDiscoveryTerminationCallback);
+    }
+
+    void descriptorDiscoveryTermination(
+        const CharacteristicDescriptorDiscovery::TerminationCallbackParams_t *) {
+        /*
+         * We do not check params->status because we really only care that the
+         * CCCD is found and that the write procedure succeeded/failed and not
+         * the discovery procedure
+         */
+        if (_cccdFound) {
+            /* The CCCD was found and write was triggered */
+            delete this;
+            return;
+        }
+
+        /* The CCCD was not found post a callback to the user to report failure */
+        GattWriteCallbackParams callbackParams;
+        callbackParams.connHandle = _characteristic.getConnectionHandle();
+        callbackParams.handle     = GattAttribute::INVALID_HANDLE;
+        callbackParams.writeOp    = GattWriteCallbackParams::OP_INVALID;
+        callbackParams.offset     = 0;
+        callbackParams.len        = 0;
+        callbackParams.data       = NULL;
+        _callback.call(&callbackParams);
+
+        delete this;
+    }
+
+    void descriptorDiscovered(
+        const CharacteristicDescriptorDiscovery::DiscoveryCallbackParams_t *params) {
+        UUID cccdUuid(BLE_UUID_DESCRIPTOR_CLIENT_CHAR_CONFIG);
+        if (params->descriptor.getUUID() == cccdUuid) {
+            /* This is the CCCD that we need to write */
+            /* Update setter config information */
+            _cccdFound = true;
+            /* Terminate the characteristic descriptor discovery */
+            _client->terminateCharacteristicDescriptorDiscovery(params->characteristic);
+            /*
+             * Write the descriptor with the new value, this will trigger a
+             * callback to user code that will report the final status of the write
+             */
+            ble_error_t error = _client->write(
+                GattClient::GATT_OP_WRITE_REQ,
+                _characteristic.getConnectionHandle(),
+                params->descriptor.getAttributeHandle(),
+                sizeof(CCCDSetter::_cccdData),
+                (const uint8_t*) &_cccdData
+            );
+            if (error != BLE_ERROR_NONE) {
+                /* Report the error and terminate */
+                GattWriteCallbackParams callbackParams;
+                callbackParams.connHandle = _characteristic.getConnectionHandle();
+                callbackParams.handle     = params->descriptor.getAttributeHandle();
+                callbackParams.writeOp    = GattWriteCallbackParams::OP_WRITE_REQ;
+                callbackParams.offset     = 0;
+                callbackParams.len        = 0;
+                callbackParams.data       = NULL;
+                _callback.call(&callbackParams);
+            }
+        }
+    }
+
+    GattClient*                 _client;
+    DiscoveredCharacteristic    _characteristic;
+    GattClient::WriteCallback_t _callback;
+    uint16_t                    _cccdData;
+    bool                        _cccdFound;
+};
+
+#endif /* __CCCDSETTER_H__ */

--- a/ble/DiscoveredCharacteristic.h
+++ b/ble/DiscoveredCharacteristic.h
@@ -265,6 +265,26 @@ public:
         uuid.setupLong(longUUID, order);
     }
 
+    /**
+     * Write the characteristic's Client Characteristic Configuration Descriptor
+     * (CCCD) to enable/disable indications and notifications.
+     *
+     * @param[in] indicationValue
+     *              The new value for the indications bit.
+     * @param[in] notificationValue
+     *              The new value for the notifications bit.
+     * @param[in] writeCallback
+     *              Callback executed at the end of the procedure.
+     *
+     * @retval BLE_ERROR_NONE if the procedure was correctly started.
+     * @retval BLE_ERROR_OPERATION_NOT_PERMITTED if the indication
+     *         characteristic does not allow updates to the notification or
+     *         indications value. In the case that one of them is locked setting
+     *         the respective parameter (i.e. @p indicationValue or
+     *         @p notificationValue) to false clears this error.
+     */
+    ble_error_t setCCCD(bool indicationValue, bool notificationValue, const GattClient::WriteCallback_t &writeCallback) const;
+
 public:
     /**
      * @brief Get the UUID of the discovered characteristic

--- a/ble/DiscoveredCharacteristicDescriptor.h
+++ b/ble/DiscoveredCharacteristicDescriptor.h
@@ -22,6 +22,7 @@
 #include "GattAttribute.h"
 #include "GattClient.h"
 #include "CharacteristicDescriptorDiscovery.h"
+#include "OneShotWriteCallback.h"
 
 /**
  * @brief Representation of a descriptor discovered during a GattClient
@@ -99,6 +100,34 @@ public:
      */
     GattAttribute::Handle_t getAttributeHandle() const {
         return _gattHandle;
+    }
+
+    /**
+     * @brief Initiate the write procedure of this characteristic descriptor.
+     *
+     * @param[in] lenght
+     *              Length in bytes of the data to write.
+     * @param[in] value
+     *              Pointer to the data to write.
+     * @param[in] callback
+     *              The callback executed at the end of the write procedure.
+     *
+     * @return BLE_ERROR_NONE if the write procedure was successfully started.
+     */
+    ble_error_t write(uint16_t length, const uint8_t *value, const GattClient::WriteCallback_t& callback) const {
+        ble_error_t error = _client->write(
+            GattClient::GATT_OP_WRITE_REQ,
+            _connectionHandle,
+            _gattHandle,
+            length,
+            value
+        );
+
+        if (error == BLE_ERROR_NONE) {
+            OneShotWriteCallback::launch(_client, _connectionHandle, _gattHandle, callback);
+        }
+
+        return error;
     }
 
 private:

--- a/ble/OneShotReadCallback.h
+++ b/ble/OneShotReadCallback.h
@@ -2,8 +2,8 @@
 #include "Gap.h"
 #include "GattAttribute.h"
 
-#ifndef __ONE_SHOT_READ_CALLBACK_H__
-#define __ONE_SHOT_READ_CALLBACK_H__
+#ifndef __ONESHOTREADCALLBACK_H__
+#define __ONESHOTREADCALLBACK_H__
 
 class OneShotReadCallback {
 public:
@@ -41,4 +41,4 @@ private:
     GattClient::ReadCallback_t _callback;
 };
 
-#endif /* __ONE_SHOT_READ_CALLBACK_H__ */
+#endif /* __ONESHOTREADCALLBACK_H__ */

--- a/ble/OneShotReadCallback.h
+++ b/ble/OneShotReadCallback.h
@@ -1,0 +1,44 @@
+#include "GattClient.h"
+#include "Gap.h"
+#include "GattAttribute.h"
+
+#ifndef __ONE_SHOT_READ_CALLBACK_H__
+#define __ONE_SHOT_READ_CALLBACK_H__
+
+class OneShotReadCallback {
+public:
+    static void launch(GattClient* client, Gap::Handle_t connHandle,
+                       GattAttribute::Handle_t handle, const GattClient::ReadCallback_t& cb) {
+        OneShotReadCallback* oneShot = new OneShotReadCallback(client, connHandle, handle, cb);
+        oneShot->attach();
+        // delete will be made when this callback is called
+    }
+
+private:
+    OneShotReadCallback(GattClient* client, Gap::Handle_t connHandle,
+                        GattAttribute::Handle_t handle, const GattClient::ReadCallback_t& cb) :
+        _client(client),
+        _connHandle(connHandle),
+        _handle(handle),
+        _callback(cb) { }
+
+    void attach() {
+        _client->onDataRead(makeFunctionPointer(this, &OneShotReadCallback::call));
+    }
+
+    void call(const GattReadCallbackParams* params) {
+        // verifiy that it is the right characteristic on the right connection
+        if (params->connHandle == _connHandle && params->handle == _handle) {
+            _callback(params);
+            _client->onDataRead().detach(makeFunctionPointer(this, &OneShotReadCallback::call));
+            delete this;
+        }
+    }
+
+    GattClient* _client;
+    Gap::Handle_t _connHandle;
+    GattAttribute::Handle_t _handle;
+    GattClient::ReadCallback_t _callback;
+};
+
+#endif /* __ONE_SHOT_READ_CALLBACK_H__ */

--- a/ble/OneShotWriteCallback.h
+++ b/ble/OneShotWriteCallback.h
@@ -2,8 +2,8 @@
 #include "Gap.h"
 #include "GattAttribute.h"
 
-#ifndef __ONE_SHOT_WRITE_CALLBACK_H__
-#define __ONE_SHOT_WRITE_CALLBACK_H__
+#ifndef __ONESHOTWRITECALLBACK_H__
+#define __ONESHOTWRITECALLBACK_H__
 
 class OneShotWriteCallback {
 public:
@@ -41,4 +41,4 @@ private:
     GattClient::WriteCallback_t _callback;
 };
 
-#endif /* __ONE_SHOT_WRITE_CALLBACK_H__ */
+#endif /* __ONESHOTWRITECALLBACK_H__ */

--- a/ble/OneShotWriteCallback.h
+++ b/ble/OneShotWriteCallback.h
@@ -1,0 +1,44 @@
+#include "GattClient.h"
+#include "Gap.h"
+#include "GattAttribute.h"
+
+#ifndef __ONE_SHOT_WRITE_CALLBACK_H__
+#define __ONE_SHOT_WRITE_CALLBACK_H__
+
+class OneShotWriteCallback {
+public:
+    static void launch(GattClient* client, Gap::Handle_t connHandle,
+                       GattAttribute::Handle_t handle, const GattClient::WriteCallback_t& cb) {
+        OneShotWriteCallback* oneShot = new OneShotWriteCallback(client, connHandle, handle, cb);
+        oneShot->attach();
+        // delete will be made when this callback is called
+    }
+
+private:
+    OneShotWriteCallback(GattClient* client, Gap::Handle_t connHandle,
+                        GattAttribute::Handle_t handle, const GattClient::WriteCallback_t& cb) :
+        _client(client),
+        _connHandle(connHandle),
+        _handle(handle),
+        _callback(cb) { }
+
+    void attach() {
+        _client->onDataWritten(makeFunctionPointer(this, &OneShotWriteCallback::call));
+    }
+
+    void call(const GattWriteCallbackParams* params) {
+        // verifiy that it is the right characteristic on the right connection
+        if (params->connHandle == _connHandle && params->handle == _handle) {
+            _callback(params);
+            _client->onDataWritten().detach(makeFunctionPointer(this, &OneShotWriteCallback::call));
+            delete this;
+        }
+    }
+
+    GattClient* _client;
+    Gap::Handle_t _connHandle;
+    GattAttribute::Handle_t _handle;
+    GattClient::WriteCallback_t _callback;
+};
+
+#endif /* __ONE_SHOT_WRITE_CALLBACK_H__ */

--- a/source/DiscoveredCharacteristic.cpp
+++ b/source/DiscoveredCharacteristic.cpp
@@ -16,6 +16,9 @@
 
 #include "ble/DiscoveredCharacteristic.h"
 #include "ble/GattClient.h"
+#include "ble/OneShotWriteCallback.h"
+#include "ble/OneShotReadCallback.h"
+#include "ble/CCCDSetter.h"
 
 ble_error_t
 DiscoveredCharacteristic::read(uint16_t offset) const
@@ -30,41 +33,6 @@ DiscoveredCharacteristic::read(uint16_t offset) const
 
     return gattc->read(connHandle, valueHandle, offset);
 }
-
-struct OneShotReadCallback {
-    static void launch(GattClient* client, Gap::Handle_t connHandle,
-                       GattAttribute::Handle_t handle, const GattClient::ReadCallback_t& cb) {
-        OneShotReadCallback* oneShot = new OneShotReadCallback(client, connHandle, handle, cb);
-        oneShot->attach();
-        // delete will be made when this callback is called
-    }
-
-private:
-    OneShotReadCallback(GattClient* client, Gap::Handle_t connHandle,
-                        GattAttribute::Handle_t handle, const GattClient::ReadCallback_t& cb) :
-        _client(client),
-        _connHandle(connHandle),
-        _handle(handle),
-        _callback(cb) { }
-
-    void attach() {
-        _client->onDataRead(makeFunctionPointer(this, &OneShotReadCallback::call));
-    }
-
-    void call(const GattReadCallbackParams* params) {
-        // verifiy that it is the right characteristic on the right connection
-        if (params->connHandle == _connHandle && params->handle == _handle) {
-            _callback(params);
-            _client->onDataRead().detach(makeFunctionPointer(this, &OneShotReadCallback::call));
-            delete this;
-        }
-    }
-
-    GattClient* _client;
-    Gap::Handle_t _connHandle;
-    GattAttribute::Handle_t _handle;
-    GattClient::ReadCallback_t _callback;
-};
 
 ble_error_t DiscoveredCharacteristic::read(uint16_t offset, const GattClient::ReadCallback_t& onRead) const {
     ble_error_t error = read(offset);
@@ -105,41 +73,6 @@ DiscoveredCharacteristic::writeWoResponse(uint16_t length, const uint8_t *value)
     return gattc->write(GattClient::GATT_OP_WRITE_CMD, connHandle, valueHandle, length, value);
 }
 
-struct OneShotWriteCallback {
-    static void launch(GattClient* client, Gap::Handle_t connHandle,
-                       GattAttribute::Handle_t handle, const GattClient::WriteCallback_t& cb) {
-        OneShotWriteCallback* oneShot = new OneShotWriteCallback(client, connHandle, handle, cb);
-        oneShot->attach();
-        // delete will be made when this callback is called
-    }
-
-private:
-    OneShotWriteCallback(GattClient* client, Gap::Handle_t connHandle,
-                        GattAttribute::Handle_t handle, const GattClient::WriteCallback_t& cb) :
-        _client(client),
-        _connHandle(connHandle),
-        _handle(handle),
-        _callback(cb) { }
-
-    void attach() {
-        _client->onDataWritten(makeFunctionPointer(this, &OneShotWriteCallback::call));
-    }
-
-    void call(const GattWriteCallbackParams* params) {
-        // verifiy that it is the right characteristic on the right connection
-        if (params->connHandle == _connHandle && params->handle == _handle) {
-            _callback(params);
-            _client->onDataWritten().detach(makeFunctionPointer(this, &OneShotWriteCallback::call));
-            delete this;
-        }
-    }
-
-    GattClient* _client;
-    Gap::Handle_t _connHandle;
-    GattAttribute::Handle_t _handle;
-    GattClient::WriteCallback_t _callback;
-};
-
 ble_error_t DiscoveredCharacteristic::write(uint16_t length, const uint8_t *value, const GattClient::WriteCallback_t& onRead) const {
     ble_error_t error = write(length, value);
     if (error) {
@@ -152,7 +85,7 @@ ble_error_t DiscoveredCharacteristic::write(uint16_t length, const uint8_t *valu
 }
 
 ble_error_t DiscoveredCharacteristic::discoverDescriptors(
-    const CharacteristicDescriptorDiscovery::DiscoveryCallback_t& onCharacteristicDiscovered, 
+    const CharacteristicDescriptorDiscovery::DiscoveryCallback_t& onCharacteristicDiscovered,
     const CharacteristicDescriptorDiscovery::TerminationCallback_t& onTermination) const {
 
     if(!gattc) {
@@ -164,4 +97,21 @@ ble_error_t DiscoveredCharacteristic::discoverDescriptors(
     );
 
     return err;
+}
+
+ble_error_t DiscoveredCharacteristic::setCCCD(
+    bool indicationValue,
+    bool notificationValue,
+    const GattClient::WriteCallback_t &writeCallback) const {
+    if (!props.notify() && notificationValue) {
+        return BLE_ERROR_OPERATION_NOT_PERMITTED;
+    }
+    if (!props.indicate() && indicationValue) {
+        return BLE_ERROR_OPERATION_NOT_PERMITTED;
+    }
+
+    /* Configure the internal structure to prepare for descriptor update */
+    CCCDSetter::launch(gattc, *this, writeCallback, notificationValue | (indicationValue << 1));
+
+    return BLE_ERROR_NONE;
 }


### PR DESCRIPTION
This is an initial version of an API that automates the process of setting the
Client Characteristic Configuration Descriptor (CCCD) to enable/disable
notifications. The new API is DiscoveredCharacteristic::setCCCD().

The new API internally triggers a characteristic descriptor discovery procedure
to find the handle of the CCCD. If this succeeds, it attempts to execute a write
procedure. On termination, a user configured callback is executed to report the
final outcome of the process.

**NOTE:** This pull request is NOT READY FOR MERGE, it is an early version of the new API to start discussion around this issue. In my opinion, there are still a few problems that need to be tackled:

1. OneShotWriteCallback, OneShotReadCallback and CCCDSetter should register onDisconnection callbacks otherwise they might never terminate if there is an unexpected disconnection while they are still active.
1. In https://github.com/ARMmbed/ble/compare/develop...andresag01:toggle_char_notification?expand=1#diff-a13de77d383409d7aa801fd6b2053b43R117 the new write() member in DiscoveredCharacteristicDescriptor does not check whether its parent characteristic actually allows write operations.
1. CCCDSetter::launch (and OneShotWriteCallback::launch, OneShotReadCallback::launch as well) do not return ble_error_t, so its impossible to check whether they actually succeeded.

@pan- Please comment.