### PR TITLE
Change onShutdown(obj, func) definition

### DIFF
--- a/ble/Gap.h
+++ b/ble/Gap.h
@@ -1635,7 +1635,7 @@ public:
      *              invoked in response to a shutdown event.
      */
     template <typename T>
-    void onShutdown(T *objPtr, void (T::*memberPtr)(void)) {
+    void onShutdown(T *objPtr, void (T::*memberPtr)(const Gap *)) {
         shutdownCallChain.add(objPtr, memberPtr);
     }
 

--- a/ble/GattClient.h
+++ b/ble/GattClient.h
@@ -491,7 +491,7 @@ public:
      *              invoked.
      */
     template <typename T>
-    void onShutdown(T *objPtr, void (T::*memberPtr)(void)) {
+    void onShutdown(T *objPtr, void (T::*memberPtr)(const GattClient *)) {
         shutdownCallChain.add(objPtr, memberPtr);
     }
 

--- a/ble/GattServer.h
+++ b/ble/GattServer.h
@@ -481,7 +481,7 @@ public:
      *              invoked.
      */
     template <typename T>
-    void onShutdown(T *objPtr, void (T::*memberPtr)(void)) {
+    void onShutdown(T *objPtr, void (T::*memberPtr)(const GattServer *)) {
         shutdownCallChain.add(objPtr, memberPtr);
     }
 

--- a/ble/SecurityManager.h
+++ b/ble/SecurityManager.h
@@ -205,7 +205,7 @@ public:
         shutdownCallChain.add(callback);
     }
     template <typename T>
-    void onShutdown(T *objPtr, void (T::*memberPtr)(void)) {
+    void onShutdown(T *objPtr, void (T::*memberPtr)(const SecurityManager *)) {
         shutdownCallChain.add(objPtr, memberPtr);
     }
 


### PR DESCRIPTION
Change onShutdown(obj, func) definition for func so that it takes the same
arguments as function-only callbacks rather than void.`
@pan-