### PR TITLE
Implement Immediate Alert Service

### DIFF
--- a/ble/services/ImmediateAlertService.h
+++ b/ble/services/ImmediateAlertService.h
@@ -1,0 +1,94 @@
+/*
+ * ImmediateAlertService.h
+ *
+ *  Created on: 2016-02-02
+ *      Author: KUANG Qi
+ */
+
+#ifndef __BLE_IMMEDIATE_ALERT_SERVICE_H__
+#define __BLE_IMMEDIATE_ALERT_SERVICE_H__
+
+#include "ble/BLE.h"
+
+class ImmediateAlertService
+{
+public:
+    enum AlertLevel_t
+    {
+        NO_ALERT = 0,
+        MILD_ALERT = 1,
+        HIGH_ALERT = 2
+    };
+
+    typedef void (*callback_t)(AlertLevel_t level);
+
+    /**
+     * @param[ref] ble
+     *               BLE object for the underlying controller.
+     */
+    ImmediateAlertService(BLE &bleIn, callback_t callbackIn,
+            AlertLevel_t levelIn = NO_ALERT) :
+            ble(bleIn), alertLevel(levelIn), callback(callbackIn), alertLevelChar(
+                    GattCharacteristic::UUID_ALERT_LEVEL_CHAR,
+                    reinterpret_cast<uint8_t *>(&alertLevel), 1, 1,
+                    GattCharacteristic::BLE_GATT_CHAR_PROPERTIES_WRITE_WITHOUT_RESPONSE)
+    {
+        static bool serviceAdded = false; /* We should only ever add one Immdiate Alert service. */
+        if (serviceAdded)
+        {
+            return;
+        }
+
+        GattCharacteristic *charTable[] =
+        { &alertLevelChar };
+        GattService immediateAlertService(
+                GattService::UUID_IMMEDIATE_ALERT_SERVICE, charTable,
+                sizeof(charTable) / sizeof(GattCharacteristic *));
+        ble.gattServer().addService(immediateAlertService);
+        serviceAdded = true;
+
+        ble.gattServer().onDataWritten(this,
+                &ImmediateAlertService::onDataWritten);
+    }
+
+    /**
+     * Update the callback.
+     */
+    void setCallback(callback_t newCallback)
+    {
+        callback = newCallback;
+    }
+
+    /**
+     * Update alertness level.
+     */
+    void setAlertLevel(AlertLevel_t newLevel)
+    {
+        alertLevel = newLevel;
+    }
+
+protected:
+    /**
+     * This callback allows receiving updates to the AlertLevel characteristic.
+     *
+     * @param[in] params
+     *     Information about the characterisitc being updated.
+     */
+    virtual void onDataWritten(const GattWriteCallbackParams *params)
+    {
+        if (params->handle == alertLevelChar.getValueHandle())
+        {
+            alertLevel = *reinterpret_cast<const AlertLevel_t *>(params->data);
+            callback(alertLevel);
+        }
+    }
+
+protected:
+    BLE &ble;
+    AlertLevel_t alertLevel;
+    callback_t callback;
+    GattCharacteristic alertLevelChar;
+
+};
+
+#endif /* __BLE_IMMEDIATE_ALERT_SERVICE_H__ */


### PR DESCRIPTION
[Immediate Alert Service](https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.immediate_alert.xml) is a simple service which exposes a control point to allow a peer device to cause the device to immediately alert.

This pull request implements this service.

Here's the demo program. Write 0, 1 or 2 to the characteristic Alert Level could cause the LED to blink.

```cpp
#include "mbed.h"
#include "ble/BLE.h"
#include "ble/services/ImmediateAlertService.h"

Ticker alertTimer;

DigitalOut led(LED1, 0);

static const char *DEVICE_NAME = "Alert";
static const uint16_t uuid16_list[] = {GattService::UUID_IMMEDIATE_ALERT_SERVICE};

ImmediateAlertService *alert;

void tickAlertHandler()
{
	led = !led;
}

void alertHandler(ImmediateAlertService::AlertLevel_t alertLevel)
{
    /* Blink a LED if an alert is received */
    if(alertLevel == ImmediateAlertService::NO_ALERT)
    {
        alertTimer.detach();
        led = 0;
    }
    if(alertLevel == ImmediateAlertService::MILD_ALERT)
    {
        alertTimer.attach(tickAlertHandler, 1.0);
    }
    if(alertLevel == ImmediateAlertService::HIGH_ALERT)
    {
        alertTimer.attach(tickAlertHandler, 0.25);
    }
}

void disconnectionCallback(const Gap::DisconnectionCallbackParams_t *)
{
    BLE::Instance(BLE::DEFAULT_INSTANCE).gap().startAdvertising();
    /* Cancel the alert if on disconnecting */
    led = 0;
    alert->setAlertLevel(ImmediateAlertService::NO_ALERT);
    alertHandler(ImmediateAlertService::NO_ALERT);
}

void bleInitComplete(BLE::InitializationCompleteCallbackContext *params)
{
    BLE &ble          = params->ble;
    ble_error_t error = params->error;

    if (error != BLE_ERROR_NONE) {
        return;
    }

    ble.gap().onDisconnection(disconnectionCallback);

    /* Setup advertising */
    ble.gap().accumulateAdvertisingPayload(GapAdvertisingData::BREDR_NOT_SUPPORTED | GapAdvertisingData::LE_GENERAL_DISCOVERABLE); // BLE only, no classic BT
    ble.gap().setAdvertisingType(GapAdvertisingParams::ADV_CONNECTABLE_UNDIRECTED); // advertising type
    ble.gap().accumulateAdvertisingPayload(GapAdvertisingData::COMPLETE_LOCAL_NAME, (uint8_t *)DEVICE_NAME, sizeof(DEVICE_NAME)); // add name
    ble.gap().accumulateAdvertisingPayload(GapAdvertisingData::COMPLETE_LIST_16BIT_SERVICE_IDS, (uint8_t *)uuid16_list, sizeof(uuid16_list)); // UUID's broadcast in advertising packet
    ble.gap().setAdvertisingInterval(100); // 100ms.

    /* Add service */
    alert  = new ImmediateAlertService(ble, alertHandler);

    /* Start advertising */
    ble.gap().startAdvertising();
}

int main(void)
{
	BLE& ble = BLE::Instance(BLE::DEFAULT_INSTANCE);
	ble.init(bleInitComplete);

    while (!ble.hasInitialized()) { /* spin loop */ }

    while (true) {
        ble.waitForEvent(); // allows or low power operation
    }
}
```