### PR TITLE
Add an interface which allows user code to customise the way BLE events are processed.

### DIFF
--- a/ble/BLE.h
+++ b/ble/BLE.h
@@ -1528,6 +1528,7 @@ public:
      * work.
      * By registering a callback, user code can know when event processing has to be
      * scheduled.
+     * Callback format is void (*)(BLE& ble);
      */
     void onEventsToProcess(const OnEventsToProcessCallback_t& callback);
 

--- a/ble/BLEInstanceBase.h
+++ b/ble/BLEInstanceBase.h
@@ -36,6 +36,13 @@ class GattClient;
 class BLEInstanceBase
 {
 public:
+    BLEInstanceBase() {}
+
+    /**
+     * Virtual destructor of the interface.
+     */
+    virtual ~BLEInstanceBase();
+
     /**
      * Initialize the underlying BLE stack. This should be called before
      * anything else in the BLE API.
@@ -135,6 +142,25 @@ public:
      * refer to BLE::waitForEvent().
      */
     virtual void                   waitForEvent(void)         = 0;
+
+    /**
+     * Process ALL pending events living in the BLE stack .
+     * Return once all events have been consumed.
+     */
+    virtual void processEvents() = 0;
+
+    /**
+     * This function allow the BLE stack to signal that their is work to do and
+     * event processing should be done (BLE::processEvent()).
+     * @param id: The ID of the BLE instance which does have events to process.
+     */
+    void signalEventsToProcess(BLE::InstanceID_t id);
+
+private:
+    // this class is not a value type.
+    // prohibit copy construction and copy assignement
+    BLEInstanceBase(const BLEInstanceBase&);
+    BLEInstanceBase& operator=(const BLEInstanceBase&);
 };
 
 /**

--- a/source/BLE.cpp
+++ b/source/BLE.cpp
@@ -25,6 +25,11 @@
 #include <minar/minar.h>
 #endif
 
+#if !defined(YOTTA_CFG_MBED_OS)
+#include <mbed_error.h>
+#include <toolchain.h>
+#endif
+
 ble_error_t
 BLE::initImplementation(FunctionPointerWithContext<InitializationCompleteCallbackContext*> callback)
 {
@@ -82,6 +87,20 @@ BLE::initImplementation(FunctionPointerWithContext<InitializationCompleteCallbac
  * This may be overridden.
  */
 #define INITIALIZER_LIST_FOR_INSTANCE_CONSTRUCTORS createBLEInstance
+
+// yotta unlike mbed-cli has proper dependency mechanisms
+// It is not required to defined a stub for createBLEInstance
+#if !defined(YOTTA_CFG_MBED_OS)
+
+// this stub is required by ARMCC otherwise link will systematically fail
+MBED_WEAK BLEInstanceBase* createBLEInstance() {
+    error("Please provide an implementation for mbed BLE");
+    return NULL;
+}
+
+#endif
+
+
 #endif /* YOTTA_CFG_BLE_INSTANCES_COUNT */
 
 typedef BLEInstanceBase *(*InstanceConstructor_t)(void);

--- a/source/BLEInstanceBase.cpp
+++ b/source/BLEInstanceBase.cpp
@@ -1,0 +1,28 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ble/BLE.h"
+#include "ble/BLEInstanceBase.h"
+
+BLEInstanceBase::~BLEInstanceBase()
+{
+    // empty destructor
+}
+
+void BLEInstanceBase::signalEventsToProcess(BLE::InstanceID_t id)
+{
+    BLE::Instance(id).signalEventsToProcess();
+}


### PR DESCRIPTION
The mechanism is quite simple:
  * user code can process all events pending in the internal BLE stack by
    calling the function BLE::processEvent.
  * user code can be notified when an event become available and the event
    stack has to be processed. The notification is issued by the port of
    mbed BLE.

For mbed os 3 and mbed classic, this doesn't change the existing behavior. 